### PR TITLE
fixed typo in templates

### DIFF
--- a/templates/lit/field-types/f32/Slider/edit/render.hbs
+++ b/templates/lit/field-types/f32/Slider/edit/render.hbs
@@ -1,5 +1,5 @@
 <div style="display: flex; flex-direction: row">
   <span style="margin-right: 4px">{{label}}</span>
 
-  <mwc-slider {{#if initial_value_variable}}.value=${ ({{initial_value_variable}} }{{/if}} @input=${(e: CustomEvent) => { {{variable_to_change}} = e.detail.value; } }></mwc-slider>
+  <mwc-slider {{#if initial_value_variable}}.value=${ {{initial_value_variable}} }{{/if}} @input=${(e: CustomEvent) => { {{variable_to_change}} = e.detail.value; } }></mwc-slider>
 </div>

--- a/templates/lit/field-types/u32/Slider/edit/render.hbs
+++ b/templates/lit/field-types/u32/Slider/edit/render.hbs
@@ -1,5 +1,5 @@
 <div style="display: flex; flex-direction: row">
   <span style="margin-right: 4px">{{label}}</span>
 
-  <mwc-slider {{#if initial_value_variable}}.value=${ ({{initial_value_variable}} }{{/if}} @input=${(e: CustomEvent) => { {{variable_to_change}} = e.detail.value; } } discrete></mwc-slider>
+  <mwc-slider {{#if initial_value_variable}}.value=${ {{initial_value_variable}} }{{/if}} @input=${(e: CustomEvent) => { {{variable_to_change}} = e.detail.value; } } discrete></mwc-slider>
 </div>


### PR DESCRIPTION
Fixes two typos in templates.
In that same spot, if `initial_value_variable` is of `Option<T>` type, typescript complains because the value is possibly undefined. This PR does not address this issue.