### PR TITLE
Fix transitive dependency not pinned

### DIFF
--- a/src/scaffold/zome.rs
+++ b/src/scaffold/zome.rs
@@ -339,6 +339,12 @@ pub fn add_common_zome_dependencies_to_workspace_cargo(
         &"hdk".to_string(),
         &format!("={}", hdk_version()),
     )?;
+    // TODO temporary: force pin the version because HDI does not require a specific version (^0.1.1 currently)
+    let file_tree = add_workspace_external_dependency(
+        file_tree,
+        &"holochain_integrity_types".to_string(),
+        &"=0.1.1".to_string(),
+    )?;
     let file_tree =
         add_workspace_external_dependency(file_tree, &"serde".to_string(), &"1".to_string())?;
 

--- a/src/scaffold/zome/coordinator.rs
+++ b/src/scaffold/zome/coordinator.rs
@@ -34,6 +34,7 @@ name = "{}"
 
 [dependencies]
 hdk = {{ workspace = true }}
+holochain_integrity_types = {{ workspace = true }}
 
 serde = {{ workspace = true }}
 

--- a/src/scaffold/zome/integrity.rs
+++ b/src/scaffold/zome/integrity.rs
@@ -11,6 +11,7 @@ name = "{}"
 
 [dependencies]
 hdi = {{ workspace = true }}
+holochain_integrity_types = {{ workspace = true }}
 
 serde = {{ workspace = true }}
 "#,


### PR DESCRIPTION
`holochain_integrity_types` should be pinned but is not, this forced the transitive dependency onto a compatible version.

Temporary fix to get scaffolding working