### PR TITLE
Fix linked collection templates (for 0.1)

### DIFF
--- a/templates/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.svelte{{¡if}}{{¡each}}.hbs
+++ b/templates/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.svelte{{¡if}}{{¡each}}.hbs
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { onMount, getContext } from 'svelte';
 import '@material/mwc-circular-progress';
-import type { AppAgentClient, Record, ActionHash, EntryHash, AgentPubKey } from '@holochain/client';
+import type { AppAgentClient, Record, ActionHash, EntryHash, AgentPubKey, NewEntryAction } from '@holochain/client';
 import { clientContext } from '../../contexts';
 import type { {{pascal_case ../entry_type.name}} } from './types';
 import {{pascal_case ../entry_type.name}}Detail from './{{pascal_case ../entry_type.name}}Detail.svelte';

--- a/templates/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.svelte{{¡if}}{{¡each}}.hbs
+++ b/templates/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.svelte{{¡if}}{{¡each}}.hbs
@@ -34,7 +34,7 @@ onMount(async () => {
   } catch (e) {
     error = e;
   }
-  loading = true;
+  loading = false;
 });
 
 </script>

--- a/templates/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.svelte{{¡if}}{{¡each}}.hbs
+++ b/templates/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.svelte{{¡if}}{{¡each}}.hbs
@@ -23,13 +23,14 @@ onMount(async () => {
   }
 
   try {
-    hashes = await client.callZome({
+    const records = await client.callZome({
       cap_secret: null,
       role_name: '{{dna_role_name}}',
       zome_name: '{{../coordinator_zome_manifest.name}}',
       fn_name: 'get_{{snake_case (plural ../entry_type.name)}}_for_{{snake_case linked_from.name}}',
       payload: {{camel_case linked_from.singular_arg}}
     });
+    hashes = records.map(r => {{#if (eq referenceable.hash_type "ActionHash")}}r.signed_action.hashed.hash{{else}}(r.signed_action.hashed.content as NewEntryAction).entry_hash{{/if}});
   } catch (e) {
     error = e;
   }

--- a/templates/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.svelte{{¡if}}{{¡each}}.hbs
+++ b/templates/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.svelte{{¡if}}{{¡each}}.hbs
@@ -25,7 +25,7 @@ onMount(async () => {
   try {
     const records = await client.callZome({
       cap_secret: null,
-      role_name: '{{dna_role_name}}',
+      role_name: '{{../dna_role_name}}',
       zome_name: '{{../coordinator_zome_manifest.name}}',
       fn_name: 'get_{{snake_case (plural ../entry_type.name)}}_for_{{snake_case linked_from.name}}',
       payload: {{camel_case linked_from.singular_arg}}

--- a/templates/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.svelte{{¡if}}{{¡each}}.hbs
+++ b/templates/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.svelte{{¡if}}{{¡each}}.hbs
@@ -30,7 +30,7 @@ onMount(async () => {
       fn_name: 'get_{{snake_case (plural ../entry_type.name)}}_for_{{snake_case linked_from.name}}',
       payload: {{camel_case linked_from.singular_arg}}
     });
-    hashes = records.map(r => {{#if (eq referenceable.hash_type "ActionHash")}}r.signed_action.hashed.hash{{else}}(r.signed_action.hashed.content as NewEntryAction).entry_hash{{/if}});
+    hashes = records.map(r => {{#if ../entry_type.reference_entry_hash}}(r.signed_action.hashed.content as NewEntryAction).entry_hash{{else}}r.signed_action.hashed.hash{{/if}});
   } catch (e) {
     error = e;
   }


### PR DESCRIPTION
There are a couple bugs in the modified entry detail template that prevent dependent linked entries from being loaded. This fixes both bugs. Waiting for some changes from Robbie before un-drafting this.

There's a corresponding PR #120 for the `holochain-0.2` branch.