### PR TITLE
Prevent trailing commas when field list ends in non-widget fields in EditFoo.svelte template

### DIFF
--- a/src/scaffold/entry_type.rs
+++ b/src/scaffold/entry_type.rs
@@ -101,6 +101,15 @@ pub fn scaffold_entry_type(
         }
     };
 
+    let widget_fields = fields
+        .iter()
+        .map(|f| f.clone())
+        .filter(|f| match f.widget {
+            Some(_) => true,
+            None => false
+        })
+        .collect();
+
     let reference_entry_hash = match maybe_reference_entry_hash {
         Some(r) => r.clone(),
         None => {
@@ -147,6 +156,7 @@ pub fn scaffold_entry_type(
     let entry_def = EntryDefinition {
         name: name.clone(),
         fields,
+        widget_fields,
         reference_entry_hash,
     };
 

--- a/src/scaffold/entry_type/definitions.rs
+++ b/src/scaffold/entry_type/definitions.rs
@@ -298,6 +298,7 @@ impl Referenceable {
 pub struct EntryDefinition {
     pub name: String,
     pub fields: Vec<FieldDefinition>,
+    pub widget_fields: Vec<FieldDefinition>,
     pub reference_entry_hash: bool,
 }
 

--- a/templates/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if crud.update}}Edit{{pascal_case entry_type.name}}.svelte{{¡if}}.hbs
+++ b/templates/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if crud.update}}Edit{{pascal_case entry_type.name}}.svelte{{¡if}}.hbs
@@ -39,7 +39,7 @@ let {{camel_case field_name}}: Array<{{> (concat field_type.type "/type")}} | un
 
 let errorSnackbar: Snackbar;
 
-$: {{#each entry_type.fields}}{{#if widget}}{{camel_case field_name}}{{#unless @last}}, {{/unless}}{{/if}}{{/each}};
+$: {{#each entry_type.widget_fields}}{{camel_case field_name}}{{#unless @last}}, {{/unless}}{{/each}};
 $: is{{pascal_case entry_type.name}}Valid = true{{#each entry_type.fields}}{{#if widget}}{{#if (eq cardinality "single")}} && {{> (concat field_type.type "/" widget "/is-valid") variable_to_validate=(camel_case field_name) }}{{/if}}{{#if (eq cardinality "vector")}} && {{camel_case field_name}}.every(e => {{> (concat field_type.type "/" widget "/is-valid") variable_to_validate="e" }}){{/if}}{{/if}}{{/each}};
 
 onMount(() => {
@@ -55,7 +55,7 @@ onMount(() => {
 
 async function update{{pascal_case entry_type.name}}() {
 
-  const {{camel_case entry_type.name}}: {{pascal_case entry_type.name}} = { 
+  const {{camel_case entry_type.name}}: {{pascal_case entry_type.name}} = {
   {{#each entry_type.fields}}
     {{#if widget}}
       {{#if (eq cardinality "single") }}
@@ -86,7 +86,7 @@ async function update{{pascal_case entry_type.name}}() {
         updated_{{snake_case entry_type.name}}: {{camel_case entry_type.name}}
       }
     });
-  
+
     dispatch('{{kebab_case entry_type.name}}-updated', { actionHash: updateRecord.signed_action.hashed.hash });
   } catch (e) {
     errorSnackbar.labelText = `Error updating the {{lower_case entry_type.name}}: ${e.data.data}`;
@@ -99,7 +99,7 @@ async function update{{pascal_case entry_type.name}}() {
 </mwc-snackbar>
 <div style="display: flex; flex-direction: column">
   <span style="font-size: 18px">Edit {{pascal_case entry_type.name}}</span>
-  
+
 {{#each entry_type.fields}}
   {{#if widget}}
   <div style="margin-bottom: 16px">
@@ -108,7 +108,7 @@ async function update{{pascal_case entry_type.name}}() {
     {{else}}
     {{> Vec/edit/render field_name=field_name field_type=field_type widget=widget }}
     {{/if}}
-    
+
   </div>
 
   {{/if}}
@@ -121,7 +121,7 @@ async function update{{pascal_case entry_type.name}}() {
       on:click={() => dispatch('edit-canceled')}
       style="flex: 1; margin-right: 16px"
     ></mwc-button>
-    <mwc-button 
+    <mwc-button
       raised
       label="Save"
       disabled={!is{{pascal_case entry_type.name}}Valid}


### PR DESCRIPTION
This is not the most elegant way to do things -- it duplicates data; implementing a `filter` helper for Handlebars would've been much more elegant. But the advantage of this approach is that I can actually do it ;)

I'm working on a possibly better solution that involves writing a `filter` Handlebars helper, but I'd like to get things unblocked for the hackathon this weekend