### PR TITLE
Set rust resolver = "2" in scaffolded workspaces

### DIFF
--- a/src/scaffold/app/cargo.rs
+++ b/src/scaffold/app/cargo.rs
@@ -12,7 +12,7 @@ members = [
   "dnas/*/zomes/coordinator/*",
   "dnas/*/zomes/integrity/*",
 ]
-edition = "2021"
+resolver = "2"
 
 [profile.dev]
 opt-level = "z"

--- a/src/scaffold/app/cargo.rs
+++ b/src/scaffold/app/cargo.rs
@@ -12,6 +12,7 @@ members = [
   "dnas/*/zomes/coordinator/*",
   "dnas/*/zomes/integrity/*",
 ]
+edition = "2021"
 
 [profile.dev]
 opt-level = "z"

--- a/templates/vanilla/example/Cargo.toml.hbs
+++ b/templates/vanilla/example/Cargo.toml.hbs
@@ -6,6 +6,7 @@ opt-level = "z"
 
 [workspace]
 members = ["dnas/*/zomes/coordinator/*", "dnas/*/zomes/integrity/*"]
+edition = "2021"
 
 [workspace.dependencies]
 hdi = "=0.2.4"

--- a/templates/vanilla/example/Cargo.toml.hbs
+++ b/templates/vanilla/example/Cargo.toml.hbs
@@ -6,7 +6,7 @@ opt-level = "z"
 
 [workspace]
 members = ["dnas/*/zomes/coordinator/*", "dnas/*/zomes/integrity/*"]
-edition = "2021"
+resolver = "2"
 
 [workspace.dependencies]
 hdi = "=0.2.4"


### PR DESCRIPTION
Setting resolver = "2" ensures that you can import holochain test_utils as a dev-dependency in your zomes, without it breaking zome builds.