### PR TITLE
Update vue scaffolding

### DIFF
--- a/templates/vue/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case collection_name}}.vue.hbs
+++ b/templates/vue/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case collection_name}}.vue.hbs
@@ -4,7 +4,7 @@
   </div>
 
   <div v-else style="display: flex; flex-direction: column">
-    <span v-if="error">Error fetching the {{lower_case (plural referenceable.name)}}: {{{{raw}}}} {{error.data.data}}.{{{{/raw}}}}</span>
+    <span v-if="error">Error fetching the {{lower_case (plural referenceable.name)}}: {{{{raw}}}} {{error.data}}.{{{{/raw}}}}</span>
     <div v-else-if="hashes && hashes.length > 0" style="margin-bottom: 8px">
       <{{pascal_case referenceable.name}}Detail 
         v-for="hash in hashes" 

--- a/templates/vue/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/Create{{pascal_case entry_type.name}}.vue.hbs
+++ b/templates/vue/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/Create{{pascal_case entry_type.name}}.vue.hbs
@@ -127,7 +127,7 @@ export default defineComponent({
         this.$emit('{{kebab_case entry_type.name}}-created', record.signed_action.hashed.hash);
       } catch (e: any) {
         const errorSnackbar = this.$refs['create-error'] as Snackbar;
-        errorSnackbar.labelText = `Error creating the {{lower_case entry_type.name}}: ${e.data.data}`;
+        errorSnackbar.labelText = `Error creating the {{lower_case entry_type.name}}: ${e.data}`;
         errorSnackbar.show();
       }
     },

--- a/templates/vue/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.vue{{¡if}}{{¡each}}.hbs
+++ b/templates/vue/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.vue{{¡if}}{{¡each}}.hbs
@@ -20,7 +20,7 @@
 <script lang="ts">
 import { defineComponent, inject, ComputedRef } from 'vue';
 import { decode } from '@msgpack/msgpack';
-import { AppAgentClient, Record, AgentPubKey, EntryHash, ActionHash } from '@holochain/client';
+import { AppAgentClient, Record, AgentPubKey, EntryHash, ActionHash, CallZomeResponse } from '@holochain/client';
 import '@material/mwc-circular-progress';
 import {{pascal_case ../entry_type.name}}Detail from './{{pascal_case ../entry_type.name}}Detail.vue';
 
@@ -29,7 +29,7 @@ export default defineComponent({
     {{pascal_case ../entry_type.name}}Detail
   },
   props: {
-    {{camel_case linked_from.singular_arg}}Hash: {
+    {{camel_case linked_from.singular_arg}}: {
       type: Object,
       required: true
     }
@@ -42,18 +42,19 @@ export default defineComponent({
     }
   },
   async mounted() {
-    if (this.{{camel_case linked_from.singular_arg}}Hash === undefined) {
+    if (this.{{camel_case linked_from.singular_arg}} === undefined) {
       throw new Error(`The {{camel_case linked_from.singular_arg}}Hash input is required for the {{pascal_case (plural ../entry_type.name)}}For{{pascal_case linked_from.name}} element`);
     }
 
     try {
-      this.hashes = await this.client.callZome({
+      const records = await this.client.callZome({
         cap_secret: null,
-        role_name: '{{dna_role_name}}',
+        role_name: '{{../dna_role_name}}',
         zome_name: '{{../coordinator_zome_manifest.name}}',
         fn_name: 'get_{{snake_case (plural ../entry_type.name)}}_for_{{snake_case linked_from.name}}',
-        payload: this.{{camel_case linked_from.singular_arg}}Hash,
+        payload: this.{{camel_case linked_from.singular_arg}},
       });
+      this.hashes = records.map((r: CallZomeResponse)  => r.signed_action.hashed.hash);
     } catch (e) {
       this.error = e;
     }

--- a/templates/vue/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.vue{{¡if}}{{¡each}}.hbs
+++ b/templates/vue/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.vue{{¡if}}{{¡each}}.hbs
@@ -4,7 +4,7 @@
   </div>
   
   <div v-else style="display: flex; flex-direction: column">
-    <span v-if="error">Error fetching the {{lower_case (plural ../entry_type.name)}}: {{{{raw}}}} {{error.data.data}}.{{{{/raw}}}}</span>
+    <span v-if="error">Error fetching the {{lower_case (plural ../entry_type.name)}}: {{{{raw}}}} {{error.data}}.{{{{/raw}}}}</span>
     <div v-else-if="hashes && hashes.length > 0" style="margin-bottom: 8px">
       <{{pascal_case ../entry_type.name}}Detail 
         v-for="hash in hashes" 

--- a/templates/vue/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if crud.update}}Edit{{pascal_case entry_type.name}}.vue{{¡if}}.hbs
+++ b/templates/vue/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if crud.update}}Edit{{pascal_case entry_type.name}}.vue{{¡if}}.hbs
@@ -137,7 +137,7 @@ export default defineComponent({
         this.$emit('{{kebab_case entry_type.name}}-updated', updateRecord.signed_action.hashed.hash);
       } catch (e: any) {
         const errorSnackbar = this.$refs['update-error'] as Snackbar;
-        errorSnackbar.labelText = `Error updating the {{lower_case entry_type.name}}: ${e.data.data}`;
+        errorSnackbar.labelText = `Error updating the {{lower_case entry_type.name}}: ${e.data}`;
         errorSnackbar.show();
       }
     },

--- a/templates/vue/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case entry_type.name}}Detail.vue.hbs
+++ b/templates/vue/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case entry_type.name}}Detail.vue.hbs
@@ -136,7 +136,7 @@ export default defineComponent({
         this.fetch{{pascal_case entry_type.name}}();
       } catch (e: any) {
         const errorSnackbar = this.$refs['delete-error'] as Snackbar;
-        errorSnackbar.labelText = `Error deleting the {{lower_case entry_type.name}}: ${e.data.data}`;
+        errorSnackbar.labelText = `Error deleting the {{lower_case entry_type.name}}: ${e.data}`;
         errorSnackbar.show();
       }
     }

--- a/templates/vue/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{pascal_case (plural from_referenceable.name)}}For{{pascal_case to_referenceable.name}}.vue{{¡if}}.hbs
+++ b/templates/vue/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{pascal_case (plural from_referenceable.name)}}For{{pascal_case to_referenceable.name}}.vue{{¡if}}.hbs
@@ -4,7 +4,7 @@
   </div>
   
   <div v-else style="display: flex; flex-direction: column">
-    <span v-if="error">Error fetching the {{lower_case (plural from_referenceable.name)}}: {{{{raw}}}} {{error.data.data}}.{{{{/raw}}}}</span>
+    <span v-if="error">Error fetching the {{lower_case (plural from_referenceable.name)}}: {{{{raw}}}} {{error.data}}.{{{{/raw}}}}</span>
     <div v-else-if="hashes && hashes.length > 0" style="margin-bottom: 8px">
       <{{pascal_case from_referenceable.name}}Detail 
         v-for="hash in hashes" 

--- a/templates/vue/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and to_referenceable (ne to_referenceable.hash_type 'AgentPubKey'))}}{{pascal_case (plural to_referenceable.name)}}For{{pascal_case from_referenceable.name}}.vue{{¡if}}.hbs
+++ b/templates/vue/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and to_referenceable (ne to_referenceable.hash_type 'AgentPubKey'))}}{{pascal_case (plural to_referenceable.name)}}For{{pascal_case from_referenceable.name}}.vue{{¡if}}.hbs
@@ -4,7 +4,7 @@
   </div>
 
   <div v-else style="display: flex; flex-direction: column">
-    <span v-if="error">Error fetching the {{lower_case (plural to_referenceable.name)}}: {{{{raw}}}} {{error.data.data}}.{{{{/raw}}}}</span>
+    <span v-if="error">Error fetching the {{lower_case (plural to_referenceable.name)}}: {{{{raw}}}} {{error.data}}.{{{{/raw}}}}</span>
     <div v-else-if="hashes && hashes.length > 0" style="margin-bottom: 8px">
       <{{pascal_case to_referenceable.name}}Detail 
         v-for="hash in hashes" 


### PR DESCRIPTION
I ran into some trouble trying out the tutorial forum example using the Vue scaffolding instead of svelte, so I tried to fix it. I couldn't figure out a way to easily try out my fixes without making an option to not make a nix environment, which is why I added the setup_nix option, but I can revert that if it's not useful. I think I got all the places that using `error.data.data`, but there are other places that have the extra `Hash` (making `postHashHash` instead of `postHash`). 