### PR TITLE
Fix broken package.json for holo

### DIFF
--- a/templates/lit/web-app/package.json.hbs
+++ b/templates/lit/web-app/package.json.hbs
@@ -23,10 +23,10 @@
     "@holochain-playground/cli": "^0.1.1",
     "concurrently": "^6.2.1",
     "rimraf": "^3.0.2",
-    "new-port-cli": "^1.0.0"
   {{#if holo_enabled}}
     "concurrently-repeat": "^0.0.1",
   {{/if}}
+    "new-port-cli": "^1.0.0"
   },
   "engines": {
     "npm": ">=7.0.0"

--- a/templates/svelte/web-app/package.json.hbs
+++ b/templates/svelte/web-app/package.json.hbs
@@ -17,16 +17,16 @@
   {{/if}}
     "package": "npm run build:happ && npm run package -w ui && hc web-app pack workdir --recursive",
     "build:happ": "npm run build:zomes && hc app pack workdir --recursive",
-    "build:zomes": "RUSTFLAGS='' CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown"    
+    "build:zomes": "RUSTFLAGS='' CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown"
   },
-  "devDependencies": {    
+  "devDependencies": {
     "@holochain-playground/cli": "^0.1.1",
     "concurrently": "^6.2.1",
     "rimraf": "^3.0.2",
-    "new-port-cli": "^1.0.0"
   {{#if holo_enabled}}
     "concurrently-repeat": "^0.0.1",
   {{/if}}
+    "new-port-cli": "^1.0.0"
   },
   "engines": {
     "npm": ">=7.0.0"

--- a/templates/vue/web-app/package.json.hbs
+++ b/templates/vue/web-app/package.json.hbs
@@ -23,10 +23,10 @@
     "@holochain-playground/cli": "^0.1.1",
     "concurrently": "^6.2.1",
     "rimraf": "^3.0.2",
-    "new-port-cli": "^1.0.0"
   {{#if holo_enabled}}
     "concurrently-repeat": "^0.0.1",
   {{/if}}
+    "new-port-cli": "^1.0.0"
   },
   "engines": {
     "npm": ">=7.0.0"


### PR DESCRIPTION
When trying to scaffold a Holo-enabled hApp, `npm` complained that the `package.json` wasn't actual JSON. Looks like it's all about a trailing comma. This should fix it.