### PR TITLE
Bump next version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "holochain_scaffolding_cli"
-version = "0.1.11"
+version = "0.2.0"
 description = "CLI to easily generate and modify holochain apps"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://developer.holochain.org"

--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695190832,
-        "narHash": "sha256-zLKW0gt0XBHlUWf/OHnNZrBb1ufYZVVJ9VKAtx0UP+E=",
+        "lastModified": 1699251646,
+        "narHash": "sha256-qexvfp2qfcpLfM/UCPLVTZyFgqZCyXkV0O2U4QVI0E8=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "281bad89f2f712e7397d038047f02ed8174aa06a",
+        "rev": "791672c1e0652b2b651a5bfc4c68a6281532a92d",
         "type": "github"
       },
       "original": {
@@ -288,11 +288,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694959747,
-        "narHash": "sha256-CXQ2MuledDVlVM5dLC4pB41cFlBWxRw4tCBsFrq3cRk=",
+        "lastModified": 1699099776,
+        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "970a59bd19eff3752ce552935687100c46e820a5",
+        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
         "type": "github"
       },
       "original": {
@@ -393,11 +393,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695175880,
-        "narHash": "sha256-TBR5/K3jkrd+U5mjxvRvUhlcT1Hw9jFywz1TjAGZRm4=",
+        "lastModified": 1699236891,
+        "narHash": "sha256-J0uhoYlufJncIFbM/pAoggzHK/qERB9KfQRkmYD56yo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e054ca37ee416efe9d8fc72d249ec332ef74b6d4",
+        "rev": "a7f9bf91dc5065d470cd57169a9f2ebdbdfe1f24",
         "type": "github"
       },
       "original": {
@@ -409,11 +409,11 @@
     "scaffolding": {
       "flake": false,
       "locked": {
-        "lastModified": 1695069964,
-        "narHash": "sha256-QtX2sZgBZ6pxtPrJp9RslJD0LU1KILp+Y0OVldapImA=",
+        "lastModified": 1695674679,
+        "narHash": "sha256-IwgQbgitUo61ZXYSXBAro5ThfYy/yMGmzZGTb3c6sT0=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "f0b878cdc75bb7b2748cb5f1564d4a4632504ca8",
+        "rev": "821439b8dd49d5ce594be04c4720df25e88a4dbc",
         "type": "github"
       },
       "original": {
@@ -447,11 +447,11 @@
       },
       "locked": {
         "dir": "versions/0_2",
-        "lastModified": 1695190832,
-        "narHash": "sha256-zLKW0gt0XBHlUWf/OHnNZrBb1ufYZVVJ9VKAtx0UP+E=",
+        "lastModified": 1699251646,
+        "narHash": "sha256-qexvfp2qfcpLfM/UCPLVTZyFgqZCyXkV0O2U4QVI0E8=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "281bad89f2f712e7397d038047f02ed8174aa06a",
+        "rev": "791672c1e0652b2b651a5bfc4c68a6281532a92d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The versions between Holochain 0.1 and Holochain 0.2 aren't distinguished but it is important which version of scaffolding works against each. I propose we follow Holochain's minor version which makes it easy to match them. The patch versions need not match and can be incremented with each scaffolding release for that version of Holochain