### PR TITLE
Detect Nix failure due to Git conflict

### DIFF
--- a/src/scaffold/app/nix.rs
+++ b/src/scaffold/app/nix.rs
@@ -59,6 +59,23 @@ pub fn setup_nix_developer_environment(dir: &PathBuf) -> ScaffoldResult<()> {
         ));
     }
 
+    // This is here to catch the issue from this thread https://discourse.nixos.org/t/nix-flakes-nix-store-source-no-such-file-or-directory/17836
+    // If you run Scaffolding inside a Git repository when the `nix flake update` will fail. At some point Nix should report this so we don't need
+    // to worry about it but for now this helps solve a strange error message.
+    match Command::new("git")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .current_dir(dir)
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output() {
+            Ok(output) => {
+                if output.status.success() && output.stdout == b"true\n" {
+                    return Err(ScaffoldError::NixSetupError("- detected that Scaffolding is running inside an existing Git repository, please choose a different location to scaffold".to_string()));
+                }
+            },
+            Err(_) => {} // Ignore errors, Git isn't necessarily available.
+        }
+
     println!("Setting up nix development environment...");
 
     add_extra_experimental_features()?;


### PR DESCRIPTION
There's a code comment explaining this one but I'll post the before and after here to make it clearer. When running Scaffolding inside a Git repository I was getting:

```
✔ App name (no whitespaces): · asdf
✔ Choose UI framework: · Vue
✔ Do you want to set up the holonix development environment for this project? · Yes (recommended)
Setting up nix development environment...
error: getting status of '/nix/store/2jbblm8bwyv0kq1k9r6dxy7q735d8v2c-source/asdf': No such file or directory
Error: Error setting up the nix environment
```

After this change, it tells you what the problem is:

```
✔ App name (no whitespaces): · asdf
✔ Choose UI framework: · Vue
✔ Do you want to set up the holonix development environment for this project? · Yes (recommended)
Error: Error setting up the nix environment - detected that Scaffolding is running inside an existing Git repository, please choose a different location to scaffold
```

This is very much a Nix flakes gotcha but I think it's helpful to tell people what's happening if possible.
