### PR TITLE
Refactor merge scope

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,16 +209,26 @@
 //! ...
 //! {{/if}}
 //! ```
-//! - `merge_scope`: takes existing code as its first argument, and the opening of an scope as its second. It then replaces the contents of that scope with the contents of the block:
+//! - `merge` and `match_scope`: takes existing code as its first argument, and the opening of an scope as its second. It then replaces the contents of that scope with the contents of the block:
 //!   - Example usage:
 //! ```hbs
-//! {{#merge_scope previous_file_content "export class ExistingClass {" }}
-//!   {{previous_scope_content}} // This will be replaced with the existing content of the scope
+//! {{#merge previous_file_content}}
+//!   {{#match_scope "export class ExistingClassA {" }}
 //!
-//!   newFunction() {
-//!     // This is a new function that will be added at the end of "ExistingClass"
-//!   }
-//! {{/merge_scope}}
+//!     newFunction() {
+//!       // This is a new function that will be added at the end of "ExistingClassA"
+//!     }
+//!   {{/match_scope}}
+//!   {{#match_scope "export class ExistingClassB {" }}
+//!
+//!     {{#merge previous_scope_content}}
+//!       {{#match_scope "newFunction() {" }}
+//!     // Will add a line at the end of newFunction
+//!       {{/match_scope}}
+//!     {{/merge}}
+//!
+//!   {{/match_scope}}
+//! {{/merge}}
 //! ```
 
 pub mod cli;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,13 @@
 //!   - `camel_case`: converts the string to camel case.
 //! - `plural`: converts the given string to its plural.
 //! - `concat`: concatenize strings.
+//! - `contains`: check whether list contains an element.
+//!   - Example usage:
+//! ```hbs
+//! {{#if (contains entry_type_list "Profile")}}
+//! ...
+//! {{/if}}
+//! ```
 //! - `includes`: check whether a string includes a substring.
 //!   - Example usage:
 //! ```hbs
@@ -209,11 +216,14 @@
 //! ...
 //! {{/if}}
 //! ```
-//! - `merge` and `match_scope`: takes existing code as its first argument, and the opening of an scope as its second. It then replaces the contents of that scope with the contents of the block:
+//! - `merge` and `match_scope`: a pair of helpers useful to add some new code to an already existing code structure, respecting their scope (`{` and `}`) structure.
+//!   - `merge`: takes existing code as its only argument.
+//!   - `match_scope`: needs to be placed inside a `merge` helper block, and takes the opening of an scope as only argument. It then searches the argument of the `merge` helper for a scope matching that opening of the scope, and replaces its contents with the contents of the `match_scope` block:
 //!   - Example usage:
 //! ```hbs
 //! {{#merge previous_file_content}}
 //!   {{#match_scope "export class ExistingClassA {" }}
+//!     {{previous_scope_content}} // Variable containing the previous content of the scope
 //!
 //!     newFunction() {
 //!       // This is a new function that will be added at the end of "ExistingClassA"
@@ -223,6 +233,7 @@
 //!
 //!     {{#merge previous_scope_content}}
 //!       {{#match_scope "newFunction() {" }}
+//!     {{previous_scope_content}}
 //!     // Will add a line at the end of newFunction
 //!       {{/match_scope}}
 //!     {{/merge}}

--- a/src/scaffold/link_type/coordinator.rs
+++ b/src/scaffold/link_type/coordinator.rs
@@ -253,12 +253,6 @@ fn remove_link_handlers(
     let singular_snake_to_entry_type = to_referenceable
         .to_string(&Cardinality::Single)
         .to_case(Case::Snake);
-    let plural_snake_to_entry_type = to_referenceable
-        .to_string(&Cardinality::Vector)
-        .to_case(Case::Snake);
-    let plural_snake_from_entry_type = from_referenceable
-        .to_string(&Cardinality::Vector)
-        .to_case(Case::Snake);
 
     let from_link = from_link_hash_type(&to_hash_type);
     let from_inverse = from_link_hash_type(&from_hash_type);

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,12 +1,9 @@
 use build_fs_tree::serde::Serialize;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::Select;
-use handlebars::{
-    handlebars_helper, Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext,
-    RenderError, Renderable, StringOutput,
-};
+use handlebars::Handlebars;
 use regex::Regex;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::path::PathBuf;
 

--- a/src/templates/helpers.rs
+++ b/src/templates/helpers.rs
@@ -1,7 +1,6 @@
 use convert_case::{Case, Casing};
 use handlebars::{
-    handlebars_helper, Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext,
-    RenderError, Renderable, StringOutput,
+    handlebars_helper, Context, Handlebars, Helper, HelperResult, Output, RenderContext,
 };
 use serde_json::Value;
 

--- a/src/templates/helpers.rs
+++ b/src/templates/helpers.rs
@@ -1,0 +1,103 @@
+use convert_case::{Case, Casing};
+use handlebars::{
+    handlebars_helper, Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext,
+    RenderError, Renderable, StringOutput,
+};
+use serde_json::Value;
+
+pub mod merge;
+pub mod uniq_lines;
+
+use merge::register_merge;
+use uniq_lines::register_uniq_lines;
+
+pub fn register_helpers<'a>(h: Handlebars<'a>) -> Handlebars<'a> {
+    let h = register_concat_helper(h);
+    let h = register_contains_helper(h);
+    let h = register_includes_helper(h);
+    let h = register_case_helpers(h);
+    let h = register_replace_helper(h);
+    let h = register_pluralize_helpers(h);
+    let h = register_merge(h);
+    let h = register_uniq_lines(h);
+
+    h
+}
+
+pub fn register_concat_helper<'a>(mut h: Handlebars<'a>) -> Handlebars<'a> {
+    h.register_helper(
+        "concat",
+        Box::new(
+            |h: &Helper,
+             _r: &Handlebars,
+             _: &Context,
+             _rc: &mut RenderContext,
+             out: &mut dyn Output|
+             -> HelperResult {
+                let result = h
+                    .params()
+                    .into_iter()
+                    .map(|p| p.render())
+                    .collect::<Vec<String>>()
+                    .join("");
+
+                out.write(result.as_ref())?;
+                Ok(())
+            },
+        ),
+    );
+
+    h
+}
+
+pub fn register_contains_helper<'a>(mut h: Handlebars<'a>) -> Handlebars<'a> {
+    handlebars_helper!(contains: |list: Option<Vec<Value>>, value: Value| list.is_some() && list.unwrap().contains(&value));
+    h.register_helper("contains", Box::new(contains));
+
+    h
+}
+
+pub fn register_includes_helper<'a>(mut h: Handlebars<'a>) -> Handlebars<'a> {
+    handlebars_helper!(includes: |string: String, substring: String| string.contains(&substring));
+    h.register_helper("includes", Box::new(includes));
+
+    h
+}
+
+pub fn register_replace_helper<'a>(mut h: Handlebars<'a>) -> Handlebars<'a> {
+    handlebars_helper!(replace: |s: String, pattern: String, replaced_by: String| s.replace(&pattern, replaced_by.as_str()));
+    h.register_helper("replace", Box::new(replace));
+
+    h
+}
+
+pub fn register_pluralize_helpers<'a>(mut h: Handlebars<'a>) -> Handlebars<'a> {
+    handlebars_helper!(singular: |s: String| pluralizer::pluralize(s.as_str(), 1, false));
+    h.register_helper("singular", Box::new(singular));
+    handlebars_helper!(plural: |s: String| pluralizer::pluralize(s.as_str(), 2, false));
+    h.register_helper("plural", Box::new(plural));
+
+    h
+}
+
+pub fn register_case_helpers<'a>(mut h: Handlebars<'a>) -> Handlebars<'a> {
+    handlebars_helper!(title_case: |s: String| s.to_case(Case::Title));
+    h.register_helper("title_case", Box::new(title_case));
+
+    handlebars_helper!(lower_case: |s: String| s.to_case(Case::Lower));
+    h.register_helper("lower_case", Box::new(lower_case));
+
+    handlebars_helper!(snake_case: |s: String| s.to_case(Case::Snake));
+    h.register_helper("snake_case", Box::new(snake_case));
+
+    handlebars_helper!(kebab_case: |s: String| s.to_case(Case::Kebab));
+    h.register_helper("kebab_case", Box::new(kebab_case));
+
+    handlebars_helper!(camel_case: |s: String| s.to_case(Case::Camel));
+    h.register_helper("camel_case", Box::new(camel_case));
+
+    handlebars_helper!(pascal_case: |s: String| s.to_case(Case::Pascal));
+    h.register_helper("pascal_case", Box::new(pascal_case));
+
+    h
+}

--- a/src/templates/helpers/merge.rs
+++ b/src/templates/helpers/merge.rs
@@ -1,0 +1,374 @@
+use std::collections::{BTreeMap, HashSet};
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use handlebars::{
+    handlebars_helper, Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext,
+    RenderError, Renderable, StringOutput,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Number, Value};
+
+pub fn register_merge<'a>(mut h: Handlebars<'a>) -> Handlebars<'a> {
+    h.register_helper("merge", Box::new(Merge));
+    h.register_helper("match_scope", Box::new(MatchScope));
+
+    h
+}
+
+fn get_scope_open_and_close_char_indexes(
+    text: &String,
+    scope_opener: &String,
+) -> Result<(usize, usize), RenderError> {
+    let mut index = text.find(scope_opener.as_str()).ok_or(RenderError::new(
+        "Given scope opener not found in the given parameter",
+    ))?;
+
+    index = index + scope_opener.len() - 1;
+    let scope_opener_index = index.clone();
+    let mut scope_count = 1;
+
+    while scope_count > 0 {
+        index += 1;
+        match text.chars().nth(index) {
+            Some('{') => {
+                scope_count += 1;
+            }
+            Some('}') => {
+                scope_count -= 1;
+            }
+            None => {
+                return Err(RenderError::new("Malformed scopes"));
+            }
+            _ => {}
+        }
+    }
+
+    let mut whitespace = true;
+
+    while whitespace {
+        match text.chars().nth(index - 1) {
+            Some(' ') => {
+                index -= 1;
+            }
+            _ => {
+                whitespace = false;
+            }
+        }
+    }
+
+    Ok((scope_opener_index, index))
+}
+
+#[derive(Clone, Copy)]
+pub struct Merge;
+
+impl HelperDef for Merge {
+    fn call<'reg: 'rc, 'rc>(
+        &self,
+        h: &Helper<'reg, 'rc>,
+        r: &'reg Handlebars<'reg>,
+        ctx: &'rc Context,
+        rc: &mut RenderContext<'reg, 'rc>,
+        out: &mut dyn Output,
+    ) -> HelperResult {
+        let t = h
+            .template()
+            .ok_or(RenderError::new("merge helper cannot have empty content"))?;
+
+        let s = h
+            .param(0)
+            .ok_or(RenderError::new("merge helper needs 1 parameter"))?
+            .value()
+            .as_str()
+            .ok_or(RenderError::new("merge first parameter must be a string"))?
+            .to_string();
+
+        let mut data = ctx
+            .data()
+            .as_object()
+            .ok_or(RenderError::new("Context must be an object"))?
+            .clone();
+        data.insert(String::from(SCOPE_CONTENT), Value::String(s.clone()));
+        rc.set_context(Context::wraps(data)?);
+
+        let mut inner_output = StringOutput::new();
+        t.render(r, ctx, rc, &mut inner_output)?;
+
+        if let Some(context) = rc.context() {
+            let mut data = context
+                .data()
+                .as_object()
+                .ok_or(RenderError::new("Context must be an object"))?
+                .clone();
+            if let Some(Value::Array(matched_scopes)) = data.get(MATCHED_SCOPES) {
+                let mut previous_index = s.len();
+
+                let mut matched_scopes: Vec<MatchedScopedData> = matched_scopes
+                    .into_iter()
+                    .filter_map(|ms| serde_json::from_value::<MatchedScopedData>(ms.clone()).ok())
+                    .collect();
+
+                matched_scopes.sort_by(|a, b| b.__starting_index.cmp(&a.__starting_index));
+
+                let mut full_merge_content = String::from("");
+                for matched_scope in matched_scopes {
+                    let mut full_scope_content = String::from("");
+                    let start_index = matched_scope.__starting_index;
+                    full_scope_content.push_str(matched_scope.__new_scope_content.as_str());
+                    full_scope_content.push_str(
+                        &s[(start_index + matched_scope.__old_scope_length)..previous_index],
+                    );
+                    previous_index = start_index + 1;
+                    full_merge_content.insert_str(0, full_scope_content.as_str());
+                }
+                full_merge_content.insert_str(0, &s[0..=previous_index]);
+                out.write(&full_merge_content)?;
+
+                data.remove(MATCHED_SCOPES);
+                rc.set_context(Context::wraps(data)?);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct MatchedScopedData {
+    __starting_index: usize,
+    __new_scope_content: String,
+    __old_scope_length: usize,
+}
+
+const MATCHED_SCOPES: &'static str = "__matched_scopes";
+const SCOPE_CONTENT: &'static str = "__scope_content";
+const STARTING_INDEX: &'static str = "__starting_index";
+const NEW_SCOPE_CONTENT: &'static str = "__new_scope_content";
+const OLD_SCOPE_LENGTH: &'static str = "__old_scope_length";
+
+#[derive(Clone, Copy)]
+pub struct MatchScope;
+
+impl HelperDef for MatchScope {
+    fn call<'reg: 'rc, 'rc>(
+        &self,
+        h: &Helper<'reg, 'rc>,
+        r: &'reg Handlebars<'reg>,
+        ctx: &'rc Context,
+        rc: &mut RenderContext<'reg, 'rc>,
+        _out: &mut dyn Output,
+    ) -> HelperResult {
+        let t = h
+            .template()
+            .ok_or(RenderError::new("merge helper cannot have empty content"))?;
+
+        let mut data = rc
+            .context()
+            .unwrap()
+            .data()
+            .as_object()
+            .ok_or(RenderError::new("Context must be an object"))?
+            .clone();
+
+        let Some(Value::String(scope_content)) = data.get(SCOPE_CONTENT) else {
+            return Err(RenderError::new(
+            "match_scope needs to be placed inside a merge helper",
+            ));
+        };
+
+        let scope_opener = h
+            .param(0)
+            .ok_or(RenderError::new("merge helper needs 1 parameter"))?
+            .value()
+            .as_str()
+            .ok_or(RenderError::new("merge's first parameter must be a string"))?
+            .to_string();
+
+        let (scope_opener_index, scope_close_index) =
+            get_scope_open_and_close_char_indexes(&scope_content, &scope_opener)?;
+
+        let previous_scope_content =
+            &scope_content[(scope_opener_index + 1)..scope_close_index].to_string();
+
+        data.insert(
+            String::from("previous_scope_content"),
+            Value::String(previous_scope_content.clone().trim().to_string()),
+        );
+        data.insert(
+            String::from("untrimmed_previous_scope_content"),
+            Value::String(previous_scope_content.clone().to_string()),
+        );
+
+        let mut matched_scopes = match data.get(MATCHED_SCOPES) {
+            Some(Value::Array(array)) => array.clone(),
+            _ => vec![],
+        };
+
+        rc.set_context(Context::wraps(data.clone())?);
+
+        let mut inner_output = StringOutput::new();
+        t.render(r, ctx, rc, &mut inner_output)?;
+
+        let out_string = inner_output.into_string().unwrap();
+
+        let mut map = Map::new();
+        map.insert(
+            String::from(STARTING_INDEX),
+            Value::Number(Number::from(scope_opener_index)),
+        );
+
+        map.insert(String::from(NEW_SCOPE_CONTENT), Value::String(out_string));
+        map.insert(
+            String::from(OLD_SCOPE_LENGTH),
+            Value::Number(Number::from(scope_close_index - scope_opener_index)),
+        );
+
+        matched_scopes.push(Value::Object(map));
+
+        data.insert(MATCHED_SCOPES.to_string(), Value::Array(matched_scopes));
+
+        rc.set_context(Context::wraps(data)?);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+    use handlebars::Handlebars;
+    use serde_json::{Map, Value};
+
+    #[test]
+    fn test_get_scope_open_and_close_char_indexes() {
+        let text = String::from("const s = {};");
+        let scope_opener = String::from("const s = {");
+
+        let (scope_opener_index, scope_close_index) =
+            get_scope_open_and_close_char_indexes(&text, &scope_opener).unwrap();
+
+        assert_eq!(scope_opener_index, 10);
+        assert_eq!(scope_close_index, 11);
+    }
+
+    #[test]
+    fn test_merge_match_scope_simple() {
+        let h = Handlebars::new();
+
+        let h = register_merge(h);
+
+        let code = String::from(
+            r#"class A {
+    // Multiline
+    // Comment
+}
+"#,
+        );
+        let mut map = Map::new();
+        map.insert(
+            String::from("previous_file_content"),
+            Value::String(String::from(code)),
+        );
+        let context = Context::from(Value::Object(map));
+        let template = r#"
+{{#merge previous_file_content}}
+    {{#match_scope "class A {"}}
+    nestedFn() {
+
+    }
+    {{previous_scope_content}}
+    {{/match_scope}}
+{{/merge}}
+"#;
+
+        assert_eq!(
+            h.render_template_with_context(template, &context).unwrap(),
+            r#"
+class A {
+    nestedFn() {
+
+    }
+    // Multiline
+    // Comment
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_merge_match_scope() {
+        let h = Handlebars::new();
+
+        let h = register_merge(h);
+
+        let code = String::from(
+            r#"export class A {
+    nestedFn1() {
+
+    }
+}
+export class B {
+    nestedFn() {
+        // First line
+    }
+}
+"#,
+        );
+        let mut map = Map::new();
+        map.insert(
+            String::from("previous_file_content"),
+            Value::String(String::from(code)),
+        );
+        map.insert(
+            String::from("class_functions"),
+            Value::Array(vec![
+                Value::String(String::from("nestedFn2")),
+                Value::String(String::from("nestedFn3")),
+            ]),
+        );
+        let context = Context::from(Value::Object(map));
+        let template = r#"{{#merge previous_file_content}}
+    {{#match_scope "export class B {"}}
+        {{#merge untrimmed_previous_scope_content}}
+            {{#match_scope "nestedFn() {"}}
+        {{previous_scope_content}}
+        // New line
+            {{/match_scope}}
+        {{/merge}}
+    {{/match_scope}}
+    {{#match_scope "export class A {"}}
+        {{#each class_functions}}
+    {{this}}() {
+
+    }
+        {{/each}}
+    {{previous_scope_content}}
+    {{/match_scope}}
+{{/merge}}
+"#;
+
+        assert_eq!(
+            h.render_template_with_context(template, &context).unwrap(),
+            r#"export class A {
+    nestedFn2() {
+
+    }
+    nestedFn3() {
+
+    }
+    nestedFn1() {
+
+    }
+}
+export class B {
+    nestedFn() {
+        // First line
+        // New line
+    }
+}
+"#,
+        );
+    }
+}

--- a/src/templates/helpers/merge.rs
+++ b/src/templates/helpers/merge.rs
@@ -1,10 +1,6 @@
-use std::collections::{BTreeMap, HashSet};
-use std::ffi::OsString;
-use std::path::PathBuf;
-
 use handlebars::{
-    handlebars_helper, Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext,
-    RenderError, Renderable, StringOutput,
+    Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext, RenderError,
+    Renderable, StringOutput,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Number, Value};

--- a/src/templates/helpers/uniq_lines.rs
+++ b/src/templates/helpers/uniq_lines.rs
@@ -1,0 +1,46 @@
+use std::collections::HashSet;
+
+use handlebars::{
+    handlebars_helper, Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext,
+    RenderError, Renderable, StringOutput,
+};
+
+#[derive(Clone, Copy)]
+pub struct UniqLines;
+
+impl HelperDef for UniqLines {
+    fn call<'reg: 'rc, 'rc>(
+        &self,
+        h: &Helper<'reg, 'rc>,
+        r: &'reg Handlebars<'reg>,
+        ctx: &'rc Context,
+        rc: &mut RenderContext<'reg, 'rc>,
+        out: &mut dyn Output,
+    ) -> HelperResult {
+        let t = h.template().ok_or(RenderError::new(
+            "uniq_lines helper cannot have empty content",
+        ))?;
+
+        let mut string_output = StringOutput::new();
+        t.render(r, ctx, rc, &mut string_output)?;
+
+        let rendered_string = string_output.into_string()?;
+
+        let unique_lines: Vec<String> = rendered_string
+            .split('\n')
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect::<HashSet<String>>()
+            .into_iter()
+            .collect();
+
+        out.write(unique_lines.join("\n").as_str())?;
+        Ok(())
+    }
+}
+
+pub fn register_uniq_lines<'a>(mut h: Handlebars<'a>) -> Handlebars<'a> {
+    h.register_helper("uniq_lines", Box::new(UniqLines));
+
+    h
+}

--- a/src/templates/helpers/uniq_lines.rs
+++ b/src/templates/helpers/uniq_lines.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 
 use handlebars::{
-    handlebars_helper, Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext,
-    RenderError, Renderable, StringOutput,
+    Context, Handlebars, Helper, HelperDef, HelperResult, Output, RenderContext, RenderError,
+    Renderable, StringOutput,
 };
 
 #[derive(Clone, Copy)]

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,9 +1,9 @@
 pub fn tryorama_version() -> String {
-    String::from("^0.15.0-rc.1")
+    String::from("^0.15.2")
 }
 
 pub fn holochain_client_version() -> String {
-    String::from("^0.15.0")
+    String::from("^0.16.5")
 }
 
 pub fn web_sdk_version() -> String {


### PR DESCRIPTION
Depends on https://github.com/holochain/scaffolding/pull/155

Refactors the `merge_scope` helper into two separate ones. [Here is the new documentation for them](https://github.com/holochain/scaffolding/blob/6f7189ea77acef72bdd867508788459e31f1ac24/src/lib.rs#L219).

Without this, the use of `merge_scope` turns out to be quite constrained in some use cases, particularly when the template needs to merge two scopes at the same level. As an example:

```ts
export class A {
}
export class B {
}
```

With the old `merge_scopes`, it was impossible to add a new function to the end of both `A` _and_ `B`, you had to choose between one of them. Now with the new helpers the templates can do it like this:

```
{{#merge previous_file_content}}
  {{#match_scope "export class A"}}
    {{previous_scope_content}}
    
    newFunctionA() {}
  {{/match_scope}}
  {{#match_scope "export class B"}}
    {{previous_scope_content}}
    
    newFunctionB() {}
  {{/match_scope}}
{{/merge}}
```

This has no impact on the built-in templates as they don't use this helper, but [this custom template does](https://github.com/holochain-open-dev/templates). I'm the maintainer of that template and I need this change for it to work well.