### PR TITLE
Rename #[hdk_entry_defs] to #[hdk_entry_types] for 0.3 compatability

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -132,13 +132,13 @@ pub enum ScaffoldError {
     #[error("Invalid example type: \"{0}\". Allowed example types: \"{1}\"")]
     InvalidExampleType(String, String),
 
-    #[error("No entry type definitions (#[hdk_entry_defs]) were found in dna \"{0}\" for the integrity zome \"{1}\"")]
+    #[error("No entry type definitions (#[hdk_entry_types]) were found in dna \"{0}\" for the integrity zome \"{1}\"")]
     NoEntryTypesDefFoundForIntegrityZome(String, String),
 
     #[error("Entry type \"{0}\" already exists in dna \"{1}\" for the integrity zome \"{2}\"")]
     EntryTypeAlreadyExists(String, String, String),
 
-    #[error("Multiple entry type definitions (#[hdk_entry_defs]) were found in dna \"{0}\" for the integrity zome \"{1}\"")]
+    #[error("Multiple entry type definitions (#[hdk_entry_types]) were found in dna \"{0}\" for the integrity zome \"{1}\"")]
     MultipleEntryTypesDefsFoundForIntegrityZome(String, String),
 
     #[error("Entry type \"{0}\" was not found in dna \"{1}\" for the integrity zome \"{2}\"")]

--- a/src/scaffold/entry_type/integrity.rs
+++ b/src/scaffold/entry_type/integrity.rs
@@ -305,7 +305,7 @@ pub use {}::*;
         .iter()
         .map(|s| s.to_os_string())
         .collect();
-    // 3. Find the #[hdk_entry_defs] macro
+    // 3. Find the #[hdk_entry_types] macro
     // 3.1 Import the new struct
     // 3.2 Add a variant for the new entry def with the struct as its payload
     map_rust_files(
@@ -320,7 +320,7 @@ pub use {}::*;
                 let entry_types_item = syn::parse_str::<syn::Item>(
                     "#[derive(Serialize, Deserialize)]
                      #[serde(tag = \"type\")]
-                     #[hdk_entry_defs]
+                     #[hdk_entry_types]
                      #[unit_enum(UnitEntryTypes)]
                      pub enum EntryTypes {}",
                 )?;
@@ -380,7 +380,7 @@ pub use {}::*;
                     .map(|mut i| {
                         if let syn::Item::Enum(mut item_enum) = i.clone() {
                             if item_enum.attrs.iter().any(|a| {
-                                a.path().segments.iter().any(|s| s.ident.eq("hdk_entry_defs"))
+                                a.path().segments.iter().any(|s| s.ident.eq("hdk_entry_types"))
                             }) {
                                 if item_enum
                                     .variants
@@ -451,7 +451,7 @@ pub fn get_all_entry_types(
                     if item_enum
                         .attrs
                         .iter()
-                        .any(|a| a.path().segments.iter().any(|s| s.ident.eq("hdk_entry_defs")))
+                        .any(|a| a.path().segments.iter().any(|s| s.ident.eq("hdk_entry_types")))
                     {
                         return Some(item_enum.clone());
                     }

--- a/templates/vanilla/example/dnas/hello_world/zomes/integrity/hello_world/src/lib.rs.hbs
+++ b/templates/vanilla/example/dnas/hello_world/zomes/integrity/hello_world/src/lib.rs.hbs
@@ -10,7 +10,7 @@ pub struct Hello {
 /// Definition of the Hello entry type itself using the entry-helper struct as its content
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type")]
-#[hdk_entry_defs]
+#[hdk_entry_types]
 #[unit_enum(UnitEntryTypes)]
 pub enum EntryTypes {
     Hello(Hello), 


### PR DESCRIPTION
Waiting on holochain 0.3 release and update of scaffolding to support 0.3 -- adding the draft PR now so I don't forget

- updates `#[hdk_entry_defs]` to `#[hdk_entry_types]` for 0.3 compatibility (see https://github.com/holochain/holochain/pull/2979)