### PR TITLE
Add holo-dev-server to the dev shell when --holo is passed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scope: [ hello_world ]
+        scope:
+          - hello_world
+          - holo_integration
     steps:
       - uses: actions/checkout@v4
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -83,8 +83,56 @@ setup_and_build_hello_world() {
   cd ..
 }
 
-if [[ -n "$SCOPE" && "$SCOPE" == "hello_world" ]]; then
-  setup_and_build_hello_world
+if [[ -n "$SCOPE" ]]; then
+
+  case "$SCOPE" in
+  "hello_world")
+    setup_and_build_hello_world
+    ;;
+  "holo_integration")
+    rm -rf /tmp/holo-flake
+    cd /tmp
+
+    hc-scaffold --template vue web-app holo-flake --setup-nix true
+    cd holo-flake
+
+    nix develop --command bash -c "
+      set -e
+      # Check if holo-dev-server is in the path
+      if command -v holo-dev-server >/dev/null 2>&1; then
+        echo 'holo-dev-server is available in the PATH while it should not'
+        exit 1
+      else
+        echo 'holo-dev-server is NOT available in the PATH'
+      fi
+    "
+
+    rm -rf /tmp/holo-flake
+    cd /tmp
+
+    hc-scaffold --template vue web-app holo-flake --setup-nix true --holo
+    cd holo-flake
+
+    nix develop --command bash -c "
+      set -e
+      # Check if holo-dev-server is in the path
+      if command -v holo-dev-server >/dev/null 2>&1; then
+        echo 'holo-dev-server is available in the PATH'
+      else
+        echo 'holo-dev-server is NOT available in the PATH'
+        exit 1
+      fi
+    "
+
+    rm -rf /tmp/holo-flake
+    cd /tmp
+    ;;
+  *)
+    echo "Error: SCOPE must be one of 'hello_world', 'holo_integration', but got $SCOPE."
+    exit 1
+    ;;
+  esac
+
   exit 0 # Exit early
 fi
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -10,93 +10,97 @@ SCOPE=
 # parse args
 while getopts ":t:s:" opt; do
   case $opt in
-    t) TEMPLATE_NAME="$OPTARG";;
-    s) SCOPE="$OPTARG";;
-    \?) echo "Invalid option: -$OPTARG" >&2
-        exit 1;;
-    :)  echo "Option -$OPTARG requires an argument." >&2
-        exit 1;;
+  t) TEMPLATE_NAME="$OPTARG" ;;
+  s) SCOPE="$OPTARG" ;;
+  \?)
+    echo "Invalid option: -$OPTARG" >&2
+    exit 1
+    ;;
+  :)
+    echo "Option -$OPTARG requires an argument." >&2
+    exit 1
+    ;;
   esac
 done
 
 cleanup_tmp() {
-	rm -rf $TEMPLATE_PATH/$1
+  rm -rf "${TEMPLATE_PATH:?}/$1"
 }
 
 print_version() {
-	echo $(hc-scaffold --version)
+  echo "$(hc-scaffold --version)"
 }
 
 setup_and_build_happ() {
-	print_version
-	cleanup_tmp $1
+  print_version
+  cleanup_tmp "$1"
 
-	cd $TEMPLATE_PATH
-	hc-scaffold --template $2 web-app $1 --setup-nix true 
-	cd $1
+  cd $TEMPLATE_PATH
+  hc-scaffold --template "$2" web-app "$1" --setup-nix true
+  cd "$1"
 
-	hc-scaffold dna forum
-	hc-scaffold zome posts --integrity dnas/forum/zomes/integrity/ --coordinator dnas/forum/zomes/coordinator/
-	hc-scaffold entry-type post --reference-entry-hash false --crud crud --link-from-original-to-each-update true --fields title:String:TextField,content:String:TextArea
-	hc-scaffold entry-type comment --reference-entry-hash false --crud crud --link-from-original-to-each-update false --fields post_hash:ActionHash::Post
-	hc-scaffold entry-type like --reference-entry-hash false --crud crd --fields like_hash:Option\<ActionHash\>::Like,string_list:Vec\<String\>
-	hc-scaffold entry-type certificate --reference-entry-hash true --crud cr --fields post_hash:ActionHash::Post,agent:AgentPubKey::certified,certifications_hashes:Vec\<EntryHash\>::Certificate,certificate_type:Enum::CertificateType:TypeOne.TypeTwo,dna_hash:DnaHash
+  hc-scaffold dna forum
+  hc-scaffold zome posts --integrity dnas/forum/zomes/integrity/ --coordinator dnas/forum/zomes/coordinator/
+  hc-scaffold entry-type post --reference-entry-hash false --crud crud --link-from-original-to-each-update true --fields title:String:TextField,content:String:TextArea
+  hc-scaffold entry-type comment --reference-entry-hash false --crud crud --link-from-original-to-each-update false --fields post_hash:ActionHash::Post
+  hc-scaffold entry-type like --reference-entry-hash false --crud crd --fields like_hash:Option\<ActionHash\>::Like,string_list:Vec\<String\>
+  hc-scaffold entry-type certificate --reference-entry-hash true --crud cr --fields post_hash:ActionHash::Post,agent:AgentPubKey::certified,certifications_hashes:Vec\<EntryHash\>::Certificate,certificate_type:Enum::CertificateType:TypeOne.TypeTwo,dna_hash:DnaHash
 
-	hc-scaffold collection global all_posts post
-	hc-scaffold collection by-author posts_by_author post
-	hc-scaffold collection global all_likes like
-	hc-scaffold collection global all_posts_entry_hash post:EntryHash
-	hc-scaffold collection by-author posts_by_author_entry_hash post:EntryHash
+  hc-scaffold collection global all_posts post
+  hc-scaffold collection by-author posts_by_author post
+  hc-scaffold collection global all_likes like
+  hc-scaffold collection global all_posts_entry_hash post:EntryHash
+  hc-scaffold collection by-author posts_by_author_entry_hash post:EntryHash
 
-	hc-scaffold link-type post like --delete true --bidirectional false
-	hc-scaffold link-type comment like:EntryHash --delete true --bidirectional true
-	hc-scaffold link-type certificate:EntryHash like --delete false --bidirectional false
-	hc-scaffold link-type agent:creator post:EntryHash --delete false --bidirectional true
+  hc-scaffold link-type post like --delete true --bidirectional false
+  hc-scaffold link-type comment like:EntryHash --delete true --bidirectional true
+  hc-scaffold link-type certificate:EntryHash like --delete false --bidirectional false
+  hc-scaffold link-type agent:creator post:EntryHash --delete false --bidirectional true
 
-	nix develop --command bash -c "
+  nix develop --command bash -c "
     set -e
     npm i
     npm run build -w ui
     npm t
     npm run package
     "
-	cd ..
+  cd ..
 }
 
 setup_and_build_hello_world() {
-	print_version
-	cleanup_tmp hello-world
+  print_version
+  cleanup_tmp hello-world
 
-	cd $TEMPLATE_PATH
-	hc-scaffold --template vanilla example hello-world
-	cd hello-world
+  cd $TEMPLATE_PATH
+  hc-scaffold --template vanilla example hello-world
+  cd hello-world
 
-	nix develop --command bash -c "
+  nix develop --command bash -c "
     set -e
     npm i
     npm t 
     "
-	cd ..
+  cd ..
 }
 
 if [[ -n "$SCOPE" && "$SCOPE" == "hello_world" ]]; then
-	setup_and_build_hello_world
-	exit 0 # Exit early
+  setup_and_build_hello_world
+  exit 0 # Exit early
 fi
 
 if [[ -z "$APP_NAME" || -z "$TEMPLATE_NAME" ]]; then
-	echo "Error: APP_NAME and TEMPLATE_NAME environment variables must be set."
-	exit 1
+  echo "Error: APP_NAME and TEMPLATE_NAME environment variables must be set."
+  exit 1
 fi
 
 case "$TEMPLATE_NAME" in
 "svelte" | "lit" | "vue" | "vanilla")
-	# Valid template name, proceed
-	;;
+  # Valid template name, proceed
+  ;;
 *)
-	echo "Error: TEMPLATE_NAME must be one of 'svelte', 'lit', 'vue', or 'vanilla'."
-	exit 1
-	;;
+  echo "Error: TEMPLATE_NAME must be one of 'svelte', 'lit', 'vue', or 'vanilla'."
+  exit 1
+  ;;
 esac
 
 cleanup_tmp "$APP_NAME"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,6 +195,9 @@ pub enum HcScaffoldCommand {
     Example {
         /// Name of the example to scaffold. One of ['hello-world', 'forum'].
         example: Option<Example>,
+
+        #[structopt(long = "holo", hidden = true)]
+        holo_enabled: bool,
     },
 }
 
@@ -674,7 +677,10 @@ Collection "{}" scaffolded!
                     println!("{}", i);
                 }
             }
-            HcScaffoldCommand::Example { example } => {
+            HcScaffoldCommand::Example {
+                example,
+                holo_enabled,
+            } => {
                 let example = match example {
                     Some(e) => e,
                     None => choose_example()?,
@@ -695,7 +701,7 @@ Collection "{}" scaffolded!
                             Some(String::from("A simple 'hello world' application.")),
                             false,
                             &template_file_tree,
-                            false,
+                            holo_enabled,
                         )?;
 
                         file_tree
@@ -707,7 +713,7 @@ Collection "{}" scaffolded!
                             Some(String::from("A simple 'forum' application.")),
                             false,
                             &template_file_tree,
-                            false,
+                            holo_enabled,
                         )?;
 
                         // scaffold dna hello_world

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@
 //! web-app/
 //!
 //! Each folder corresponds to the templates that are created when running a specific command. Here are the steps executed:
-//! 
+//!
 //! 1. The user executes a scaffolding command, like `hc scaffold web-app`.
 //!   	- Optionally, they may pass a `--template` argument, specifying the template name or local path to use.
 //! 		- The `--template` value is saved in the root `package.json` file's `hcScaffold` key for future reference and to prevent the use of different templates in the same project.

--- a/src/scaffold/app.rs
+++ b/src/scaffold/app.rs
@@ -25,7 +25,7 @@ impl AppFileTree {
     pub fn file_tree(self) -> FileTree {
         self.file_tree
     }
-    
+
     pub fn file_tree_ref<'a>(&'a self) -> &'a FileTree {
         &self.file_tree
     }

--- a/src/scaffold/app/nix.rs
+++ b/src/scaffold/app/nix.rs
@@ -67,14 +67,15 @@ pub fn setup_nix_developer_environment(dir: &PathBuf) -> ScaffoldResult<()> {
         .stderr(Stdio::null())
         .current_dir(dir)
         .args(["rev-parse", "--is-inside-work-tree"])
-        .output() {
-            Ok(output) => {
-                if output.status.success() && output.stdout == b"true\n" {
-                    return Err(ScaffoldError::NixSetupError("- detected that Scaffolding is running inside an existing Git repository, please choose a different location to scaffold".to_string()));
-                }
-            },
-            Err(_) => {} // Ignore errors, Git isn't necessarily available.
+        .output()
+    {
+        Ok(output) => {
+            if output.status.success() && output.stdout == b"true\n" {
+                return Err(ScaffoldError::NixSetupError("- detected that Scaffolding is running inside an existing Git repository, please choose a different location to scaffold".to_string()));
+            }
         }
+        Err(_) => {} // Ignore errors, Git isn't necessarily available.
+    }
 
     println!("Setting up nix development environment...");
 

--- a/src/scaffold/collection/coordinator.rs
+++ b/src/scaffold/collection/coordinator.rs
@@ -192,7 +192,8 @@ fn add_delete_link_in_delete_function(
             "delete_{}",
             entry_type_reference.entry_type.to_case(Case::Snake)
         ),
-    )? else {
+    )?
+    else {
         return Ok((dna_file_tree, false));
     };
 

--- a/src/scaffold/dna/coordinator.rs
+++ b/src/scaffold/dna/coordinator.rs
@@ -17,7 +17,7 @@ pub fn new_coordinator_zome_manifest(
     let location = zome_wasm_location(&dna_file_tree, &name);
     let zome_manifest = ZomeManifest {
         name: name.clone().into(),
-        hash: None,        
+        hash: None,
         location,
         dependencies: maybe_dependencies.clone().map(|dz| {
             dz.into_iter()

--- a/src/scaffold/web_app.rs
+++ b/src/scaffold/web_app.rs
@@ -39,7 +39,7 @@ fn web_app_skeleton(
         app_file_tree
             .dir_content_mut()
             .ok_or(ScaffoldError::PathNotFound(PathBuf::new()))?
-            .insert(OsString::from("flake.nix"), flake_nix());
+            .insert(OsString::from("flake.nix"), flake_nix(holo_enabled));
     }
 
     let mut scaffold_template_result =

--- a/src/templates/example.rs
+++ b/src/templates/example.rs
@@ -4,7 +4,8 @@ use std::{ffi::OsString, path::PathBuf};
 use crate::{
     error::ScaffoldResult,
     file_tree::{file_content, FileTree},
-    scaffold::example::Example, versions::{hdi_version, hdk_version, holochain_client_version},
+    scaffold::example::Example,
+    versions::{hdi_version, hdk_version, holochain_client_version},
 };
 
 use super::{

--- a/src/templates/helpers.rs
+++ b/src/templates/helpers.rs
@@ -4,15 +4,15 @@ use handlebars::{
 };
 use serde_json::Value;
 
+pub mod file_exists;
+pub mod filter;
 pub mod merge;
 pub mod uniq_lines;
-pub mod filter;
-pub mod file_exists;
 
+use file_exists::register_file_exists;
+use filter::register_filter;
 use merge::register_merge;
 use uniq_lines::register_uniq_lines;
-use filter::register_filter;
-use file_exists::register_file_exists;
 
 pub fn register_helpers<'a>(h: Handlebars<'a>) -> Handlebars<'a> {
     let h = register_concat_helper(h);

--- a/src/templates/helpers/filter.rs
+++ b/src/templates/helpers/filter.rs
@@ -1,8 +1,5 @@
-use handlebars::{
-    Context, Handlebars, Helper, HelperDef, RenderContext, RenderError,
-    ScopedJson,
-};
-use serde_json::{json, Value, Map};
+use handlebars::{Context, Handlebars, Helper, HelperDef, RenderContext, RenderError, ScopedJson};
+use serde_json::{json, Map, Value};
 
 #[derive(Clone, Copy)]
 pub struct FilterHelper;
@@ -59,14 +56,14 @@ impl HelperDef for FilterHelper {
                             if s.as_str() == "true" {
                                 filtered_array.push(item);
                             }
-                        },
+                        }
                         Err(e) => {
                             return Err(e);
                         }
                     }
                 }
                 Ok(ScopedJson::Derived(json!(filtered_array)))
-            },
+            }
             Value::Object(object) => {
                 let mut filtered_object = Map::new();
                 for key in object.clone().keys() {
@@ -76,7 +73,7 @@ impl HelperDef for FilterHelper {
                                 if s.as_str() == "true" {
                                     filtered_object.insert(key.into(), v.clone());
                                 }
-                            },
+                            }
                             Err(e) => {
                                 return Err(e);
                             }
@@ -84,8 +81,10 @@ impl HelperDef for FilterHelper {
                     }
                 }
                 Ok(ScopedJson::Derived(json!(filtered_object)))
-            },
-            _ => Err(RenderError::new("Filter helper: value to be filtered must be an array or object"))
+            }
+            _ => Err(RenderError::new(
+                "Filter helper: value to be filtered must be an array or object",
+            )),
         }
     }
 }
@@ -98,9 +97,9 @@ pub fn register_filter<'a>(mut h: Handlebars<'a>) -> Handlebars<'a> {
 
 #[cfg(test)]
 mod tests {
+    use crate::templates::helpers::register_filter;
     use handlebars::Handlebars;
     use serde_json::json;
-    use crate::templates::helpers::register_filter;
 
     fn setup_handlebars<'a>() -> Handlebars<'a> {
         let hbs = Handlebars::new();
@@ -116,13 +115,16 @@ mod tests {
         let template = "{{#each (filter this \"this\")}}{{this}}{{/each}}";
         match hbs.render_template(&template, &value) {
             Ok(s) => assert_eq!(s, "12345", "`filter` helper did not filter out falsy zero"),
-            Err(e) => panic!("{}", e)
+            Err(e) => panic!("{}", e),
         }
         // This predicate, however, does not.
         let template = "{{#each (filter this \"this\" includeZero=true)}}{{this}}{{/each}}";
         match hbs.render_template(&template, &value) {
-            Ok(s) => assert_eq!(s, "0102030405", "`filter` helper did not treat zero as truthy"),
-            Err(e) => panic!("{}", e)
+            Ok(s) => assert_eq!(
+                s, "0102030405",
+                "`filter` helper did not treat zero as truthy"
+            ),
+            Err(e) => panic!("{}", e),
         }
     }
 
@@ -133,11 +135,13 @@ mod tests {
         // The predicate filters out the 'wild' property.
         let template = "{{#each (filter this \"this\")}}{{@key}}: {{this}}, {{/each}}";
         match hbs.render_template(&template, &value) {
-            Ok(s) => assert_eq!(s, "name: Alice, age: 24, species: iguana, ", "`filter` helper did not filter object key/value pairs by value"),
-            Err(e) => panic!("{}", e)
+            Ok(s) => assert_eq!(
+                s, "name: Alice, age: 24, species: iguana, ",
+                "`filter` helper did not filter object key/value pairs by value"
+            ),
+            Err(e) => panic!("{}", e),
         }
     }
-
 
     #[test]
     fn can_filter_complex_value() {
@@ -148,10 +152,14 @@ mod tests {
             {"name": "Carol", "age": 1, "wild": true, "species": "octopus"}
         ]);
         // The predicate filters out domestic animals.
-        let template = "{{#each (filter this \"wild\")}}{{name}} the {{species}} is {{age}}. {{/each}}";
+        let template =
+            "{{#each (filter this \"wild\")}}{{name}} the {{species}} is {{age}}. {{/each}}";
         match hbs.render_template(&template, &value) {
-            Ok(s) => assert_eq!(s, "Alice the iguana is 24. Carol the octopus is 1. ", "`filter` helper did not operate on a list full of complex values"),
-            Err(e) => panic!("{}", e)
+            Ok(s) => assert_eq!(
+                s, "Alice the iguana is 24. Carol the octopus is 1. ",
+                "`filter` helper did not operate on a list full of complex values"
+            ),
+            Err(e) => panic!("{}", e),
         }
     }
 }

--- a/src/templates/helpers/merge.rs
+++ b/src/templates/helpers/merge.rs
@@ -164,7 +164,7 @@ impl HelperDef for MatchScope {
 
         let Some(Value::String(scope_content)) = data.get(SCOPE_CONTENT) else {
             return Err(RenderError::new(
-            "match_scope needs to be placed inside a merge helper",
+                "match_scope needs to be placed inside a merge helper",
             ));
         };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -89,10 +89,10 @@ pub fn input_yes_or_no(prompt: &String, recommended: Option<bool>) -> ScaffoldRe
     }
 }
 
-pub fn input_with_custom_validation<'a, V>(prompt: &str, validator: V) -> ScaffoldResult<String> 
-    where
-        V: Validator<String> + 'a,
-        V::Err: ToString,
+pub fn input_with_custom_validation<'a, V>(prompt: &str, validator: V) -> ScaffoldResult<String>
+where
+    V: Validator<String> + 'a,
+    V::Err: ToString,
 {
     let input: String = Input::with_theme(&ColorfulTheme::default())
         .with_prompt(prompt)


### PR DESCRIPTION
We add a --holo flag to the example subcommand.
When this flag is passed, we add holo-nixpkgs as a flake input and we add holo-dev-server to the dev shell's packages.

This PR builds on #165 that was opened by @alastairong