### PR TITLE
refactor: Refactor templates module and handle unhandled errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,6 +2915,7 @@ dependencies = [
  "include_dir",
  "itertools 0.10.5",
  "mr_bundle",
+ "once_cell",
  "path-clean",
  "pluralizer",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,4 @@ colored = "2.1.0"
 dprint-plugin-typescript = "0.91.1"
 dprint-plugin-vue = { git = "https://github.com/c12i/dprint-plugin-vue.git", version = "0.6.0"}
 git2 = "0.19.0"
+once_cell = "1.19.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -142,7 +142,7 @@ pub enum ScaffoldError {
     FsBuildError(#[from] build_fs_tree::BuildError<PathBuf, io::Error>),
 
     /// anything else
-    #[error("Unknown error: {0}")]
+    #[error("Unexpected error: {0}")]
     MiscError(#[from] anyhow::Error),
 }
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use build_fs_tree::serde::Serialize;
 use handlebars::Handlebars;
 use regex::Regex;
@@ -21,6 +22,12 @@ pub mod example;
 pub mod integrity;
 pub mod link_type;
 pub mod web_app;
+
+const EACH_TEMPLATE_REGEX: &str =
+    r"(?P<c>(.)*)/\{\{#each (?P<b>([^\{\}])*)\}\}(?P<a>(.)*)\{\{/each\}\}.hbs\z";
+const EACH_IF_TEMPLATE_REGEX: &str = r"(?P<c>(.)*)/\{\{#each (?P<b>([^\{\}])*)\}\}\{\{#if (?P<d>([^\{\}])*)\}\}(?P<a>(.)*)\{\{/if\}\}\{\{/each\}\}.hbs\z";
+const IF_TEMPLATE_REGEX: &str =
+    r"(?P<c>(.)*)/\{\{#if (?P<b>([^\{\}])*)\}\}(?P<a>(.)*)\{\{/if\}\}.hbs\z";
 
 pub struct ScaffoldedTemplate {
     pub file_tree: FileTree,
@@ -48,17 +55,17 @@ pub fn register_all_partials_in_dir<'a>(
     file_tree: &FileTree,
 ) -> ScaffoldResult<Handlebars<'a>> {
     let partials = find_files(file_tree, &|path, _contents| {
-        if let Some(e) = PathBuf::from(path).extension() {
-            if e == "hbs" {
-                return true;
-            }
-        }
-        false
+        PathBuf::from(path)
+            .extension()
+            .map_or(false, |e| e == "hbs")
     });
 
     for (path, content) in partials {
         h.register_partial(
-            path.with_extension("").as_os_str().to_str().unwrap(),
+            path.with_extension("")
+                .as_os_str()
+                .to_str()
+                .context("Failed to convert OsStr to str")?,
             content.trim(),
         )
         .map_err(Box::new)?;
@@ -75,18 +82,20 @@ pub fn render_template_file(
     value: &serde_json::Value,
 ) -> ScaffoldResult<String> {
     let mut value = value.clone();
+    let target_path_str = target_path
+        .to_str()
+        .context("Failed to convert PathBuf to str")?;
 
     if let Ok(previous_content) = file_content(existing_app_file_tree, target_path) {
         value
             .as_object_mut()
-            .unwrap()
+            .context("Failed to get Value as a mutable object")?
             .insert("previous_file_content".into(), previous_content.into());
     }
 
     let mut h = h.clone();
-    h.register_template_string(target_path.to_str().unwrap(), template_str)
-        .map_err(Box::new)?;
-    let new_contents = h.render(target_path.to_str().unwrap(), &value)?;
+    h.register_template_string(target_path_str, template_str)?;
+    let new_contents = h.render(target_path_str, &value)?;
 
     Ok(new_contents)
 }
@@ -101,120 +110,71 @@ pub fn render_template_file_tree<T: Serialize>(
 
     let mut transformed_templates: BTreeMap<PathBuf, Option<String>> = BTreeMap::new();
 
-    let new_data = serde_json::to_string(data)?;
-    let value: serde_json::Value = serde_json::from_str(new_data.as_str())?;
-
     for (path, maybe_contents) in flattened_templates {
-        let path = PathBuf::from(path.to_str().unwrap().replace('¡', "/"));
-        let path = PathBuf::from(path.to_str().unwrap().replace('\'', "\""));
+        // Normalize the file path by replacing special characters:
+        let path = PathBuf::from(
+            path.to_str()
+                .context("Failed to convert PathBug to str")?
+                .replace('¡', "/")
+                .replace('\'', "\""),
+        );
+        let path_str = path.to_str().context("Failed to convert PathBuf to str")?;
         if let Some(contents) = maybe_contents {
-            let re = Regex::new(
-                r"(?P<c>(.)*)/\{\{#each (?P<b>([^\{\}])*)\}\}(?P<a>(.)*)\{\{/each\}\}.hbs\z",
-            )
-            .unwrap();
-            let if_regex = Regex::new(
-                r"(?P<c>(.)*)/\{\{#if (?P<b>([^\{\}])*)\}\}(?P<a>(.)*)\{\{/if\}\}.hbs\z",
-            )
-            .unwrap();
+            let each_regex =
+                Regex::new(EACH_TEMPLATE_REGEX).context("EACH_TEMPLATE_REGEX is invalid")?;
+            let if_regex = Regex::new(IF_TEMPLATE_REGEX).context("IF_TEMPLATE_REGEX is invalid")?;
 
-            if re.is_match(path.to_str().unwrap()) {
-                let path_prefix = re.replace(path.to_str().unwrap(), "${c}");
-                let path_prefix = h.render_template(path_prefix.to_string().as_str(), data)?;
+            match (each_regex.is_match(path_str), if_regex.is_match(path_str)) {
+                (true, _) => handle_each_regex_template(
+                    each_regex,
+                    h,
+                    &path,
+                    path_str,
+                    &contents,
+                    existing_app_file_tree,
+                    data,
+                    &mut transformed_templates,
+                )?,
+                (_, true) => handle_if_template_regex(
+                    if_regex,
+                    h,
+                    path_str,
+                    &contents,
+                    existing_app_file_tree,
+                    data,
+                    &mut transformed_templates,
+                )?,
+                _ => {
+                    if let Some(e) = path.extension() {
+                        if e == "hbs" {
+                            let new_path = h.render_template(
+                                path.as_os_str()
+                                    .to_str()
+                                    .context("Failed to convert OsStr to str")?,
+                                data,
+                            )?;
+                            let target_path = PathBuf::from(new_path).with_extension("");
 
-                let new_path_suffix =
-                    re.replace(path.to_str().unwrap(), "{{#each ${b} }}${a}.hbs{{/each}}");
+                            let new_contents = render_template_file(
+                                &h,
+                                existing_app_file_tree,
+                                &target_path,
+                                &contents,
+                                &serde_json::json!(data),
+                            )?;
 
-                let all_paths = h.render_template(new_path_suffix.to_string().as_str(), data)?;
-
-                let files_to_create: Vec<String> = all_paths
-                    .split(".hbs")
-                    .map(|s| s.to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect();
-
-                if !files_to_create.is_empty() {
-                    let delimiter = "\n----END_OF_FILE_DELIMITER----\n";
-
-                    let each_if_re = Regex::new(
-                    r"(?P<c>(.)*)/\{\{#each (?P<b>([^\{\}])*)\}\}\{\{#if (?P<d>([^\{\}])*)\}\}(?P<a>(.)*)\{\{/if\}\}\{\{/each\}\}.hbs\z",
-                )
-                .unwrap();
-                    let b = re.replace(path.to_str().unwrap(), "${b}");
-                    let new_all_contents = match each_if_re.is_match(path.to_str().unwrap()) {
-                        true => {
-                            let d = each_if_re.replace(path.to_str().unwrap(), "${d}");
-                            format!(
-                                "{{{{#each {} }}}}{{{{#if {} }}}}\n{}{}{{{{/if}}}}{{{{/each}}}}",
-                                b, d, contents, delimiter
-                            )
+                            transformed_templates.insert(target_path, Some(new_contents));
                         }
-
-                        false => format!(
-                            "{{{{#each {} }}}}\n{}{}{{{{/each}}}}",
-                            b, contents, delimiter
-                        ),
-                    };
-                    let new_contents = render_template_file(
-                        h,
-                        existing_app_file_tree,
-                        &path,
-                        &new_all_contents,
-                        &value,
-                    )?;
-                    let new_contents_split: Vec<String> = new_contents
-                        .split(delimiter)
-                        .map(|s| s.to_string())
-                        .collect();
-
-                    for (i, f) in files_to_create.into_iter().enumerate() {
-                        let target_path = PathBuf::from(path_prefix.clone()).join(f);
-                        let formatted_contents = format_code(&new_contents_split[i], &target_path)?;
-
-                        transformed_templates.insert(target_path, Some(formatted_contents));
                     }
-                }
-            } else if if_regex.is_match(path.to_str().unwrap()) {
-                let path_prefix = if_regex.replace(path.to_str().unwrap(), "${c}");
-                let path_prefix = h.render_template(path_prefix.to_string().as_str(), data)?;
-
-                let new_path_suffix =
-                    if_regex.replace(path.to_str().unwrap(), "{{#if ${b} }}${a}.hbs{{/if}}");
-
-                let new_template = h.render_template(new_path_suffix.to_string().as_str(), data)?;
-
-                if let Some(file_name) = new_template.strip_suffix(".hbs") {
-                    let target_path = PathBuf::from(path_prefix.clone()).join(file_name);
-
-                    let new_contents = render_template_file(
-                        h,
-                        existing_app_file_tree,
-                        &target_path,
-                        &contents,
-                        &value,
-                    )?;
-                    let formatted_contents = format_code(&new_contents, file_name)?;
-
-                    transformed_templates.insert(target_path, Some(formatted_contents));
-                }
-            } else if let Some(e) = path.extension() {
-                if e == "hbs" {
-                    let new_path = h.render_template(path.as_os_str().to_str().unwrap(), data)?;
-                    let target_path = PathBuf::from(new_path).with_extension("");
-
-                    let new_contents = render_template_file(
-                        h,
-                        existing_app_file_tree,
-                        &target_path,
-                        &contents,
-                        &value,
-                    )?;
-                    let formatted_contents = format_code(&new_contents, &target_path)?;
-
-                    transformed_templates.insert(target_path, Some(formatted_contents));
                 }
             }
         } else {
-            let new_path = h.render_template(path.as_os_str().to_str().unwrap(), data)?;
+            let new_path = h.render_template(
+                path.as_os_str()
+                    .try_into()
+                    .context("Failed to convert OsStr to str")?,
+                data,
+            )?;
             transformed_templates.insert(PathBuf::from(new_path), None);
         }
     }
@@ -222,7 +182,110 @@ pub fn render_template_file_tree<T: Serialize>(
     unflatten_file_tree(&transformed_templates)
 }
 
-pub fn render_template_file_tree_and_merge_with_existing<T: Serialize>(
+fn handle_each_regex_template<'a, T: Serialize>(
+    each_regex: Regex,
+    h: &Handlebars<'a>,
+    path: &PathBuf,
+    path_str: &str,
+    contents: &str,
+    existing_app_file_tree: &FileTree,
+    data: &T,
+    transformed_templates: &mut BTreeMap<PathBuf, Option<String>>,
+) -> ScaffoldResult<()> {
+    let path_prefix = each_regex.replace(path_str, "${c}");
+    let path_prefix = h.render_template(path_prefix.to_string().as_str(), data)?;
+
+    let new_path_suffix = each_regex.replace(path_str, "{{#each ${b} }}${a}.hbs{{/each}}");
+
+    let all_paths = h.render_template(&new_path_suffix.to_string(), data)?;
+
+    let files_to_create = all_paths
+        .split(".hbs")
+        .filter_map(|s| {
+            if s.is_empty() {
+                return None;
+            }
+            Some(s.to_string())
+        })
+        .collect::<Vec<String>>();
+
+    if files_to_create.is_empty() {
+        return Ok(());
+    }
+
+    let delimiter = "\n----END_OF_FILE_DELIMITER----\n";
+    let each_if_re =
+        Regex::new(EACH_IF_TEMPLATE_REGEX).context("EACH_IF_TEMPLATE_REGEX is invalid")?;
+    let b = each_regex.replace(path_str, "${b}");
+    let new_all_contents = match each_if_re.is_match(path_str) {
+        true => {
+            let d = each_if_re.replace(path_str, "${d}");
+            format!(
+                "{{{{#each {} }}}}{{{{#if {} }}}}\n{}{}{{{{/if}}}}{{{{/each}}}}",
+                b, d, contents, delimiter
+            )
+        }
+
+        false => {
+            format!(
+                "{{{{#each {} }}}}\n{}{}{{{{/each}}}}",
+                b, contents, delimiter
+            )
+        }
+    };
+    let new_contents = render_template_file(
+        &h,
+        existing_app_file_tree,
+        &path,
+        &new_all_contents,
+        &serde_json::json!(data),
+    )?;
+    let new_contents_split: Vec<String> = new_contents
+        .split(delimiter)
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    for (i, f) in files_to_create.into_iter().enumerate() {
+        let target_path = PathBuf::from(path_prefix.clone()).join(f);
+
+        transformed_templates.insert(target_path, Some(new_contents_split[i].clone()));
+    }
+    Ok(())
+}
+
+fn handle_if_template_regex<'a, T: Serialize>(
+    if_regex: Regex,
+    h: &Handlebars<'a>,
+    path_str: &str,
+    contents: &str,
+    existing_app_file_tree: &FileTree,
+    data: &T,
+    transformed_templates: &mut BTreeMap<PathBuf, Option<String>>,
+) -> ScaffoldResult<()> {
+    let path_prefix = if_regex.replace(path_str, "${c}");
+    let path_prefix = h.render_template(path_prefix.to_string().as_str(), data)?;
+
+    let new_path_suffix = if_regex.replace(path_str, "{{#if ${b} }}${a}.hbs{{/if}}");
+
+    let new_template = h.render_template(new_path_suffix.to_string().as_str(), data)?;
+
+    if let Some(file_name) = new_template.strip_suffix(".hbs") {
+        let target_path = PathBuf::from(path_prefix.clone()).join(file_name);
+
+        let new_contents = render_template_file(
+            &h,
+            existing_app_file_tree,
+            &target_path,
+            &contents.to_owned(),
+            &serde_json::json!(data),
+        )?;
+        transformed_templates.insert(target_path, Some(new_contents));
+    }
+    Ok(())
+}
+
+pub fn render_template_file_tree_and_merge_with_existing<'a, T: Serialize>(
     app_file_tree: FileTree,
     h: &Handlebars,
     template_file_tree: &FileTree,

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -171,7 +171,7 @@ pub fn render_template_file_tree<T: Serialize>(
         } else {
             let new_path = h.render_template(
                 path.as_os_str()
-                    .try_into()
+                    .to_str()
                     .context("Failed to convert OsStr to str")?,
                 data,
             )?;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -157,7 +157,7 @@ pub fn render_template_file_tree<T: Serialize>(
                         let target_path = PathBuf::from(new_path).with_extension("");
 
                         let new_contents = render_template_file(
-                            &h,
+                            h,
                             existing_app_file_tree,
                             &target_path,
                             &contents,
@@ -184,9 +184,9 @@ pub fn render_template_file_tree<T: Serialize>(
     unflatten_file_tree(&transformed_templates)
 }
 
-fn handle_each_regex_template<'a, T: Serialize>(
-    h: &Handlebars<'a>,
-    path: &PathBuf,
+fn handle_each_regex_template<T: Serialize>(
+    h: &Handlebars,
+    path: &Path,
     path_str: &str,
     contents: &str,
     existing_app_file_tree: &FileTree,
@@ -198,7 +198,7 @@ fn handle_each_regex_template<'a, T: Serialize>(
 
     let new_path_suffix = EACH_TEMPLATE_REGEX.replace(path_str, "{{#each ${b} }}${a}.hbs{{/each}}");
 
-    let all_paths = h.render_template(&new_path_suffix.to_string(), data)?;
+    let all_paths = h.render_template(new_path_suffix.as_ref(), data)?;
 
     let files_to_create = all_paths
         .split(".hbs")
@@ -229,15 +229,14 @@ fn handle_each_regex_template<'a, T: Serialize>(
         )
     };
     let new_contents = render_template_file(
-        &h,
+        h,
         existing_app_file_tree,
-        &path,
+        path,
         &new_all_contents,
         &serde_json::json!(data),
     )?;
     let new_contents_split: Vec<String> = new_contents
         .split(delimiter)
-        .into_iter()
         .map(|s| s.to_string())
         .collect();
 
@@ -249,8 +248,8 @@ fn handle_each_regex_template<'a, T: Serialize>(
     Ok(())
 }
 
-fn handle_if_template_regex<'a, T: Serialize>(
-    h: &Handlebars<'a>,
+fn handle_if_template_regex<T: Serialize>(
+    h: &Handlebars,
     path_str: &str,
     contents: &str,
     existing_app_file_tree: &FileTree,
@@ -268,10 +267,10 @@ fn handle_if_template_regex<'a, T: Serialize>(
         let target_path = PathBuf::from(path_prefix.clone()).join(file_name);
 
         let new_contents = render_template_file(
-            &h,
+            h,
             existing_app_file_tree,
             &target_path,
-            &contents,
+            contents,
             &serde_json::json!(data),
         )?;
         let new_contents = format_code(&new_contents, file_name)?;
@@ -281,7 +280,7 @@ fn handle_if_template_regex<'a, T: Serialize>(
     Ok(())
 }
 
-pub fn render_template_file_tree_and_merge_with_existing<'a, T: Serialize>(
+pub fn render_template_file_tree_and_merge_with_existing<T: Serialize>(
     app_file_tree: FileTree,
     h: &Handlebars,
     template_file_tree: &FileTree,

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -271,7 +271,7 @@ fn handle_if_template_regex<'a, T: Serialize>(
             &h,
             existing_app_file_tree,
             &target_path,
-            &contents.to_owned(),
+            &contents,
             &serde_json::json!(data),
         )?;
         let new_contents = format_code(&new_contents, file_name)?;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -114,7 +114,7 @@ pub fn render_template_file_tree<T: Serialize>(
         // Normalize the file path by replacing special characters:
         let path = PathBuf::from(
             path.to_str()
-                .context("Failed to convert PathBug to str")?
+                .context("Failed to convert PathBuf to str")?
                 .replace('¡', "/")
                 .replace('\'', "\""),
         );


### PR DESCRIPTION
This PR is an attempt at refactoring some the templates module, I struggled a lot with initially understanding the code and as a result would prove to be challenge in maintaining it, therefore this PR makes the following changes

- Extract the logic inside the for loop into separate functions
- Move regex strings to constants
- Prefer `match` over `if` `else if` for better readablilty
- handle errors gracefully by removing the `unwrap` calls and applying error context via anyhow where necessary, a first step in addressing #173
- perform early returns where possible