### PR TITLE
enhancement: use `parse(from_os_str)` for `PathBuf` args to handle non UTF-8 file paths on windows

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,7 +61,7 @@ pub enum HcScaffold {
         /// The git repository URL from which to download the template, incompatible with --templates-path
         templates_url: Option<String>,
 
-        #[structopt(short = "p", long)]
+        #[structopt(short = "p", long, parse(from_os_str))]
         /// The local folder path in which to look for the given template, incompatible with --templates-url
         templates_path: Option<PathBuf>,
 
@@ -99,11 +99,11 @@ pub enum HcScaffold {
         /// Name of the zome being scaffolded
         name: Option<String>,
 
-        #[structopt(long)]
+        #[structopt(long, parse(from_os_str))]
         /// Scaffold an integrity zome at the given path
         integrity: Option<PathBuf>,
 
-        #[structopt(long)]
+        #[structopt(long, parse(from_os_str))]
         /// Scaffold a coordinator zome at the given path
         coordinator: Option<PathBuf>,
 


### PR DESCRIPTION
This PR introduces a slight modification to the handling of `PathBuf` arguments in the cli. The change involves adding the `parse(from_os_str)` attribute to `PathBuf` fields to enhance the application's compatibility with file paths containing non-UTF-8 characters, particularly on Windows