### PR TITLE
Use hc-spin cli 

### DIFF
--- a/src/templates/web_app.rs
+++ b/src/templates/web_app.rs
@@ -6,7 +6,8 @@ use crate::{
     error::ScaffoldResult,
     file_tree::{file_content, FileTree},
     versions::{
-        hdi_version, hdk_version, holochain_client_version, holochain_version, tryorama_version,
+        hc_spin_version, hdi_version, hdk_version, holochain_client_version, holochain_version,
+        tryorama_version,
     },
 };
 
@@ -21,6 +22,7 @@ pub struct ScaffoldWebAppData {
     pub hdk_version: String,
     pub hdi_version: String,
     pub holochain_client_version: String,
+    pub hc_spin_version: String,
     pub tryorama_version: String,
     pub holo_enabled: bool,
 }
@@ -37,6 +39,7 @@ pub fn scaffold_web_app_template(
         hdk_version: hdk_version(),
         hdi_version: hdi_version(),
         holochain_client_version: holochain_client_version(),
+        hc_spin_version: hc_spin_version(),
         tryorama_version: tryorama_version(),
         holo_enabled,
     };

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -7,7 +7,7 @@ pub fn holochain_client_version() -> String {
 }
 
 pub fn hc_spin_version() -> String {
-    String::from("^0.200.6")
+    String::from("^0.200.7")
 }
 
 pub fn web_sdk_version() -> String {

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -3,7 +3,11 @@ pub fn tryorama_version() -> String {
 }
 
 pub fn holochain_client_version() -> String {
-    String::from("^0.16.5")
+    String::from("^0.16.7")
+}
+
+pub fn hc_spin_version() -> String {
+    String::from("^0.200.6")
 }
 
 pub fn web_sdk_version() -> String {

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -7,7 +7,7 @@ pub fn holochain_client_version() -> String {
 }
 
 pub fn hc_spin_version() -> String {
-    String::from("^0.200.7")
+    String::from("^0.200.8")
 }
 
 pub fn web_sdk_version() -> String {

--- a/templates/lit/web-app/package.json.hbs
+++ b/templates/lit/web-app/package.json.hbs
@@ -9,7 +9,10 @@
     "start": "AGENTS=2 BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) npm run network",
     "network": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently \"npm start -w ui\" \"npm run launch:happ\" \"holochain-playground\"",
     "test": "npm run build:zomes && hc app pack workdir --recursive && npm t -w tests",
-    "launch:happ": "concurrently \"hc run-local-services --bootstrap-port $BOOTSTRAP_PORT --signal-port $SIGNAL_PORT\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network --bootstrap http://127.0.0.1:\"$BOOTSTRAP_PORT\" webrtc ws://127.0.0.1:\"$SIGNAL_PORT\"\"",
+    "launch:happ": "hc-spin -n $AGENTS --ui-port $UI_PORT workdir/{{app_name}}.happ",
+    "start:tauri": "AGENTS=2 BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) npm run network:tauri",
+    "network:tauri": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently \"npm start -w ui\" \"npm run launch:tauri\" \"holochain-playground\"",
+    "launch:tauri": "concurrently \"hc run-local-services --bootstrap-port $BOOTSTRAP_PORT --signal-port $SIGNAL_PORT\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network --bootstrap http://127.0.0.1:\"$BOOTSTRAP_PORT\" webrtc ws://127.0.0.1:\"$SIGNAL_PORT\"\"",
   {{#if holo_enabled}}
     "start:holo": "AGENTS=2 npm run network:holo",
     "network:holo": "npm run build:happ && UI_PORT=8888 concurrently \"npm run launch:holo-dev-server\" \"holochain-playground ws://localhost:4444\" \"concurrently-repeat 'VITE_APP_CHAPERONE_URL=http://localhost:24274 VITE_APP_IS_HOLO=true npm start -w ui' $AGENTS\"",
@@ -21,6 +24,7 @@
   },
   "devDependencies": {
     "@holochain-playground/cli": "^0.1.1",
+    "@holochain/hc-spin": "{{hc_spin_version}}",
     "concurrently": "^6.2.1",
     "rimraf": "^3.0.2",
   {{#if holo_enabled}}

--- a/templates/svelte/web-app/package.json.hbs
+++ b/templates/svelte/web-app/package.json.hbs
@@ -9,7 +9,10 @@
     "start": "AGENTS=2 BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) npm run network",
     "network": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently \"npm start -w ui\" \"npm run launch:happ\" \"holochain-playground\"",
     "test": "npm run build:zomes && hc app pack workdir --recursive && npm t -w tests",
-    "launch:happ": "concurrently \"hc run-local-services --bootstrap-port $BOOTSTRAP_PORT --signal-port $SIGNAL_PORT\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network --bootstrap http://127.0.0.1:\"$BOOTSTRAP_PORT\" webrtc ws://127.0.0.1:\"$SIGNAL_PORT\"\"",
+    "launch:happ": "hc-spin -n $AGENTS --ui-port $UI_PORT workdir/{{app_name}}.happ",
+    "start:tauri": "AGENTS=2 BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) npm run network:tauri",
+    "network:tauri": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently \"npm start -w ui\" \"npm run launch:tauri\" \"holochain-playground\"",
+    "launch:tauri": "concurrently \"hc run-local-services --bootstrap-port $BOOTSTRAP_PORT --signal-port $SIGNAL_PORT\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network --bootstrap http://127.0.0.1:\"$BOOTSTRAP_PORT\" webrtc ws://127.0.0.1:\"$SIGNAL_PORT\"\"",
   {{#if holo_enabled}}
     "start:holo": "AGENTS=2 npm run network:holo",
     "network:holo": "npm run build:happ && UI_PORT=8888 concurrently \"npm run launch:holo-dev-server\" \"holochain-playground ws://localhost:4444\" \"concurrently-repeat 'VITE_APP_CHAPERONE_URL=http://localhost:24274 VITE_APP_IS_HOLO=true npm start -w ui' $AGENTS\"",
@@ -21,6 +24,7 @@
   },
   "devDependencies": {
     "@holochain-playground/cli": "^0.1.1",
+    "@holochain/hc-spin": "{{hc_spin_version}}",
     "concurrently": "^6.2.1",
     "rimraf": "^3.0.2",
   {{#if holo_enabled}}

--- a/templates/vanilla/web-app/package.json.hbs
+++ b/templates/vanilla/web-app/package.json.hbs
@@ -21,7 +21,7 @@
     "@holochain-playground/cli": "^0.1.1",
     "@holochain/hc-spin": "{{hc_spin_version}}",
     "concurrently": "^6.2.1",
-    "new-port-cli": "^1.0.0"
+    "new-port-cli": "^1.0.0",
     "rimraf": "^3.0.2"
   },
   "engines": {

--- a/templates/vanilla/web-app/package.json.hbs
+++ b/templates/vanilla/web-app/package.json.hbs
@@ -9,13 +9,17 @@
     "start": "AGENTS=2 npm run network",
     "network": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently \"npm start -w ui\" \"npm run launch:happ\" \"holochain-playground\"",
     "test": "npm run build:zomes && hc app pack workdir --recursive && npm t -w tests",
-    "launch:happ": "concurrently \"hc run-local-services --bootstrap-port 9998 --signal-port 9999\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network --bootstrap http://127.0.0.1:9998 webrtc ws://127.0.0.1:9999\"",
+    "launch:happ": "hc-spin -n $AGENTS --ui-port $UI_PORT workdir/{{app_name}}.happ",
+    "start:tauri": "AGENTS=2 BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) npm run network:tauri",
+    "network:tauri": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently \"npm start -w ui\" \"npm run launch:tauri\" \"holochain-playground\"",
+    "launch:tauri": "concurrently \"hc run-local-services --bootstrap-port $BOOTSTRAP_PORT --signal-port $SIGNAL_PORT\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network --bootstrap http://127.0.0.1:\"$BOOTSTRAP_PORT\" webrtc ws://127.0.0.1:\"$SIGNAL_PORT\"\"",
     "package": "npm run build:happ && npm run package -w ui && hc web-app pack workdir --recursive",
     "build:happ": "npm run build:zomes && hc app pack workdir --recursive",
     "build:zomes": "RUSTFLAGS='' CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown"
   },
   "devDependencies": {
     "@holochain-playground/cli": "^0.1.1",
+    "@holochain/hc-spin": "{{hc_spin_version}}",
     "concurrently": "^6.2.1",
     "rimraf": "^3.0.2"
   },

--- a/templates/vanilla/web-app/package.json.hbs
+++ b/templates/vanilla/web-app/package.json.hbs
@@ -21,6 +21,7 @@
     "@holochain-playground/cli": "^0.1.1",
     "@holochain/hc-spin": "{{hc_spin_version}}",
     "concurrently": "^6.2.1",
+    "new-port-cli": "^1.0.0"
     "rimraf": "^3.0.2"
   },
   "engines": {

--- a/templates/vue/web-app/package.json.hbs
+++ b/templates/vue/web-app/package.json.hbs
@@ -9,7 +9,10 @@
     "start": "AGENTS=2 BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) npm run network",
     "network": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently \"npm start -w ui\" \"npm run launch:happ\" \"holochain-playground\"",
     "test": "npm run build:zomes && hc app pack workdir --recursive && npm t -w tests",
-    "launch:happ": "concurrently \"hc run-local-services --bootstrap-port $BOOTSTRAP_PORT --signal-port $SIGNAL_PORT\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network --bootstrap http://127.0.0.1:\"$BOOTSTRAP_PORT\" webrtc ws://127.0.0.1:\"$SIGNAL_PORT\"\"",
+    "launch:happ": "hc-spin -n $AGENTS --ui-port $UI_PORT workdir/{{app_name}}.happ",
+    "start:tauri": "AGENTS=2 BOOTSTRAP_PORT=$(port) SIGNAL_PORT=$(port) npm run network:tauri",
+    "network:tauri": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently \"npm start -w ui\" \"npm run launch:tauri\" \"holochain-playground\"",
+    "launch:tauri": "concurrently \"hc run-local-services --bootstrap-port $BOOTSTRAP_PORT --signal-port $SIGNAL_PORT\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network --bootstrap http://127.0.0.1:\"$BOOTSTRAP_PORT\" webrtc ws://127.0.0.1:\"$SIGNAL_PORT\"\"",
   {{#if holo_enabled}}
     "start:holo": "AGENTS=2 npm run network:holo",
     "network:holo": "npm run build:happ && UI_PORT=8888 concurrently \"npm run launch:holo-dev-server\" \"holochain-playground ws://localhost:4444\" \"concurrently-repeat 'VITE_APP_CHAPERONE_URL=http://localhost:24274 VITE_APP_IS_HOLO=true npm start -w ui' $AGENTS\"",
@@ -21,6 +24,7 @@
   },
   "devDependencies": {
     "@holochain-playground/cli": "^0.1.1",
+    "@holochain/hc-spin": "{{hc_spin_version}}",
     "concurrently": "^6.2.1",
     "rimraf": "^3.0.2",
   {{#if holo_enabled}}


### PR DESCRIPTION
Switches to using the hc-spin CLI instead of hc launch by default since it provides better developer tools.