### PR TITLE
feat(cli): add optional flag to skip ui generation for `link-type`, `entry-type` and `collection`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -150,6 +150,10 @@ pub enum HcScaffold {
         /// The template to scaffold the dna from
         /// The template must be located at the ".templates/<TEMPLATE NAME>" folder of the repository
         template: Option<String>,
+
+        #[structopt(long, hidden = true)]
+        /// Optional flag to skip ui generation
+        skip_ui: bool,
     },
     /// Scaffold a link type and its appropriate zome functions into an existing zome
     LinkType {
@@ -181,6 +185,10 @@ pub enum HcScaffold {
         /// The template to scaffold the dna from
         /// The template must be located at the ".templates/<TEMPLATE NAME>" folder of the repository
         template: Option<String>,
+
+        #[structopt(long, hidden = true)]
+        /// Optional flag to skip ui generation
+        skip_ui: bool,
     },
     /// Scaffold a collection of entries in an existing zome
     Collection {
@@ -206,6 +214,10 @@ pub enum HcScaffold {
         /// The template to scaffold the dna from
         /// The template must be located at the ".templates/<TEMPLATE NAME>" folder of the repository
         template: Option<String>,
+
+        #[structopt(long, hidden = true)]
+        /// Optional flag to skip ui generation
+        skip_ui: bool,
     },
 
     Example {
@@ -554,6 +566,7 @@ Add new entry definitions to your zome with:
                 link_from_original_to_each_update,
                 fields,
                 template,
+                skip_ui
             } => {
                 let current_dir = std::env::current_dir()?;
                 let file_tree = load_directory_into_memory(&current_dir)?;
@@ -617,6 +630,7 @@ Add new collections for that entry type with:
                 delete,
                 bidirectional,
                 template,
+                skip_ui,
             } => {
                 let current_dir = std::env::current_dir()?;
                 let file_tree = load_directory_into_memory(&current_dir)?;
@@ -658,6 +672,7 @@ Link type scaffolded!
                 collection_type,
                 entry_type,
                 template,
+                skip_ui,
             } => {
                 let current_dir = std::env::current_dir()?;
                 let file_tree = load_directory_into_memory(&current_dir)?;
@@ -685,6 +700,7 @@ Link type scaffolded!
                     &name,
                     &collection_type,
                     &entry_type,
+                    skip_ui,
                 )?;
 
                 let file_tree = MergeableFileSystemTree::<OsString, String>::from(file_tree);
@@ -898,6 +914,7 @@ Collection "{}" scaffolded!
                                 entry_type: String::from("post"),
                                 reference_entry_hash: false,
                             }),
+                            false
                         )?;
 
                         file_tree

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,7 +152,7 @@ pub enum HcScaffold {
         template: Option<String>,
 
         #[structopt(long, hidden = true)]
-        /// Skip ui generation
+        /// Skip ui generation, overriding any widgets specified with the --fields option
         no_ui: bool,
     },
     /// Scaffold a link type and its appropriate zome functions into an existing zome

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,7 +151,7 @@ pub enum HcScaffold {
         /// The template must be located at the ".templates/<TEMPLATE NAME>" folder of the repository
         template: Option<String>,
 
-        #[structopt(long, hidden = true)]
+        #[structopt(long)]
         /// Skip ui generation, overriding any widgets specified with the --fields option
         no_ui: bool,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,7 +152,7 @@ pub enum HcScaffold {
         template: Option<String>,
 
         #[structopt(long, hidden = true)]
-        /// Optional flag to skip ui generation
+        /// Skip ui generation
         no_ui: bool,
     },
     /// Scaffold a link type and its appropriate zome functions into an existing zome
@@ -186,8 +186,8 @@ pub enum HcScaffold {
         /// The template must be located at the ".templates/<TEMPLATE NAME>" folder of the repository
         template: Option<String>,
 
-        #[structopt(long, hidden = true)]
-        /// Optional flag to skip ui generation
+        #[structopt(long)]
+        /// Skip ui generation
         no_ui: bool,
     },
     /// Scaffold a collection of entries in an existing zome
@@ -215,8 +215,8 @@ pub enum HcScaffold {
         /// The template must be located at the ".templates/<TEMPLATE NAME>" folder of the repository
         template: Option<String>,
 
-        #[structopt(long, hidden = true)]
-        /// Optional flag to skip ui generation
+        #[structopt(long)]
+        /// Skip ui generation
         no_ui: bool,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -598,6 +598,7 @@ Add new entry definitions to your zome with:
                     &reference_entry_hash,
                     &link_from_original_to_each_update,
                     &fields,
+                    no_ui,
                 )?;
 
                 let file_tree = MergeableFileSystemTree::<OsString, String>::from(file_tree);
@@ -650,6 +651,7 @@ Add new collections for that entry type with:
                     &to_referenceable,
                     &delete,
                     &bidirectional,
+                    no_ui,
                 )?;
 
                 let file_tree = MergeableFileSystemTree::<OsString, String>::from(file_tree);
@@ -854,6 +856,7 @@ Collection "{}" scaffolded!
                                     linked_from: None,
                                 },
                             ]),
+                            false,
                         )?;
 
                         let dna_file_tree =
@@ -895,6 +898,7 @@ Collection "{}" scaffolded!
                                     )),
                                 },
                             ]),
+                            false
                         )?;
 
                         let dna_file_tree =

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,7 +153,7 @@ pub enum HcScaffold {
 
         #[structopt(long, hidden = true)]
         /// Optional flag to skip ui generation
-        skip_ui: bool,
+        no_ui: bool,
     },
     /// Scaffold a link type and its appropriate zome functions into an existing zome
     LinkType {
@@ -188,7 +188,7 @@ pub enum HcScaffold {
 
         #[structopt(long, hidden = true)]
         /// Optional flag to skip ui generation
-        skip_ui: bool,
+        no_ui: bool,
     },
     /// Scaffold a collection of entries in an existing zome
     Collection {
@@ -217,7 +217,7 @@ pub enum HcScaffold {
 
         #[structopt(long, hidden = true)]
         /// Optional flag to skip ui generation
-        skip_ui: bool,
+        no_ui: bool,
     },
 
     Example {
@@ -566,7 +566,7 @@ Add new entry definitions to your zome with:
                 link_from_original_to_each_update,
                 fields,
                 template,
-                skip_ui
+                no_ui
             } => {
                 let current_dir = std::env::current_dir()?;
                 let file_tree = load_directory_into_memory(&current_dir)?;
@@ -630,7 +630,7 @@ Add new collections for that entry type with:
                 delete,
                 bidirectional,
                 template,
-                skip_ui,
+                no_ui,
             } => {
                 let current_dir = std::env::current_dir()?;
                 let file_tree = load_directory_into_memory(&current_dir)?;
@@ -672,7 +672,7 @@ Link type scaffolded!
                 collection_type,
                 entry_type,
                 template,
-                skip_ui,
+                no_ui,
             } => {
                 let current_dir = std::env::current_dir()?;
                 let file_tree = load_directory_into_memory(&current_dir)?;
@@ -700,7 +700,7 @@ Link type scaffolded!
                     &name,
                     &collection_type,
                     &entry_type,
-                    skip_ui,
+                    no_ui,
                 )?;
 
                 let file_tree = MergeableFileSystemTree::<OsString, String>::from(file_tree);

--- a/src/scaffold/collection.rs
+++ b/src/scaffold/collection.rs
@@ -70,7 +70,7 @@ pub fn scaffold_collection(
     collection_name: &String,
     maybe_collection_type: &Option<CollectionType>,
     maybe_entry_type: &Option<EntryTypeReference>,
-    skip_ui: bool,
+    no_ui: bool,
 ) -> ScaffoldResult<ScaffoldedTemplate> {
     check_for_reserved_words(collection_name)?;
 
@@ -141,6 +141,6 @@ pub fn scaffold_collection(
         collection_name,
         &entry_type,
         deletable,
-        skip_ui,
+        no_ui,
     )
 }

--- a/src/scaffold/collection.rs
+++ b/src/scaffold/collection.rs
@@ -70,6 +70,7 @@ pub fn scaffold_collection(
     collection_name: &String,
     maybe_collection_type: &Option<CollectionType>,
     maybe_entry_type: &Option<EntryTypeReference>,
+    skip_ui: bool,
 ) -> ScaffoldResult<ScaffoldedTemplate> {
     check_for_reserved_words(collection_name)?;
 
@@ -132,7 +133,7 @@ pub fn scaffold_collection(
 
     scaffold_collection_templates(
         app_file_tree.file_tree(),
-        &template_file_tree,
+        template_file_tree,
         &app_name,
         &dna_name,
         &coordinator_zome,
@@ -140,5 +141,6 @@ pub fn scaffold_collection(
         collection_name,
         &entry_type,
         deletable,
+        skip_ui,
     )
 }

--- a/src/scaffold/entry_type.rs
+++ b/src/scaffold/entry_type.rs
@@ -79,6 +79,7 @@ pub fn scaffold_entry_type(
     maybe_reference_entry_hash: &Option<bool>,
     maybe_link_from_original_to_each_update: &Option<bool>,
     maybe_fields: &Option<Vec<FieldDefinition>>,
+    no_ui: bool,
 ) -> ScaffoldResult<ScaffoldedTemplate> {
     check_for_reserved_words(name)?;
 
@@ -97,6 +98,7 @@ pub fn scaffold_entry_type(
                 name,
                 &zome_file_tree,
                 template_file_tree.path(&mut v.iter()).unwrap_or(&empty_dir),
+                no_ui,
             )?
         }
     };
@@ -235,6 +237,7 @@ pub fn scaffold_entry_type(
         &entry_def,
         &crud,
         link_from_original_to_each_update,
+        no_ui,
     )
 }
 

--- a/src/scaffold/entry_type/fields.rs
+++ b/src/scaffold/entry_type/fields.rs
@@ -160,6 +160,7 @@ pub fn choose_field(
     entry_type_name: &String,
     zome_file_tree: &ZomeFileTree,
     field_types_templates: &FileTree,
+    no_ui: bool,
 ) -> ScaffoldResult<FieldDefinition> {
     let field_types = FieldType::list();
     let field_type_names: Vec<String> = field_types
@@ -324,7 +325,11 @@ pub fn choose_field(
     let field_name: String =
         input_with_case_and_initial_text(&String::from("Field name:"), Case::Snake, &initial_text)?;
 
-    let widget = choose_widget(&field_type, field_types_templates)?;
+    let widget = if no_ui {
+        None
+    } else {
+        choose_widget(&field_type, field_types_templates)?
+    };
 
     Ok(FieldDefinition {
         widget,
@@ -339,13 +344,19 @@ pub fn choose_fields(
     entry_type_name: &String,
     zome_file_tree: &ZomeFileTree,
     field_types_templates: &FileTree,
+    no_ui: bool,
 ) -> ScaffoldResult<Vec<FieldDefinition>> {
     let mut finished = false;
     let mut fields: Vec<FieldDefinition> = Vec::new();
     println!("\nWhich fields should the entry contain?\n");
 
     while !finished {
-        let field_def = choose_field(entry_type_name, zome_file_tree, field_types_templates)?;
+        let field_def = choose_field(
+            entry_type_name,
+            zome_file_tree,
+            field_types_templates,
+            no_ui,
+        )?;
         println!("");
 
         fields.push(field_def);

--- a/src/scaffold/link_type.rs
+++ b/src/scaffold/link_type.rs
@@ -55,6 +55,7 @@ pub fn scaffold_link_type(
     to_referenceable: &Option<Referenceable>,
     delete: &Option<bool>,
     bidirectional: &Option<bool>,
+    no_ui: bool,
 ) -> ScaffoldResult<ScaffoldedTemplate> {
     let dna_manifest_path = zome_file_tree.dna_file_tree.dna_manifest_path.clone();
     let zome_manifest = zome_file_tree.zome_manifest.clone();
@@ -215,5 +216,6 @@ pub use {}::*;
         &to_referenceable,
         delete,
         &inverse_link_type,
+        no_ui,
     )
 }

--- a/src/templates/collection.rs
+++ b/src/templates/collection.rs
@@ -36,7 +36,7 @@ pub fn scaffold_collection_templates(
     collection_name: &String,
     entry_type_reference: &EntryTypeReference,
     deletable: bool,
-    skip_ui: bool,
+    no_ui: bool,
 ) -> ScaffoldResult<ScaffoldedTemplate> {
     let data = ScaffoldCollectionData {
         app_name: app_name.clone(),
@@ -56,11 +56,9 @@ pub fn scaffold_collection_templates(
     if let Some(web_app_template) = template_file_tree.path(&mut v.iter()) {
         // TODO: avoid cloning
         let mut web_app_template = web_app_template.clone();
-        if skip_ui {
+        if no_ui {
             web_app_template.dir_content_mut().and_then(|v| {
-                v.retain(|k, _| {
-                    return k.ne(&OsString::from("ui"));
-                });
+                v.retain(|k, _| k.ne(&OsString::from("ui")));
                 Some(v)
             });
         }

--- a/src/templates/collection.rs
+++ b/src/templates/collection.rs
@@ -54,7 +54,6 @@ pub fn scaffold_collection_templates(
     let v: Vec<OsString> = field_types_path.iter().map(|s| s.to_os_string()).collect();
 
     if let Some(web_app_template) = template_file_tree.path(&mut v.iter()) {
-        // TODO: avoid cloning
         let mut web_app_template = web_app_template.clone();
         if no_ui {
             web_app_template.dir_content_mut().and_then(|v| {

--- a/src/templates/collection.rs
+++ b/src/templates/collection.rs
@@ -57,8 +57,11 @@ pub fn scaffold_collection_templates(
         // TODO: avoid cloning
         let mut web_app_template = web_app_template.clone();
         if skip_ui {
-            web_app_template.dir_content_mut().unwrap().retain(|k, _| {
-                return k.ne(&OsString::from("ui"));
+            web_app_template.dir_content_mut().and_then(|v| {
+                v.retain(|k, _| {
+                    return k.ne(&OsString::from("ui"));
+                });
+                Some(v)
             });
         }
         app_file_tree = render_template_file_tree_and_merge_with_existing(

--- a/src/templates/collection.rs
+++ b/src/templates/collection.rs
@@ -36,6 +36,7 @@ pub fn scaffold_collection_templates(
     collection_name: &String,
     entry_type_reference: &EntryTypeReference,
     deletable: bool,
+    skip_ui: bool,
 ) -> ScaffoldResult<ScaffoldedTemplate> {
     let data = ScaffoldCollectionData {
         app_name: app_name.clone(),
@@ -53,10 +54,17 @@ pub fn scaffold_collection_templates(
     let v: Vec<OsString> = field_types_path.iter().map(|s| s.to_os_string()).collect();
 
     if let Some(web_app_template) = template_file_tree.path(&mut v.iter()) {
+        // TODO: avoid cloning
+        let mut web_app_template = web_app_template.clone();
+        if skip_ui {
+            web_app_template.dir_content_mut().unwrap().retain(|k, _| {
+                return k.ne(&OsString::from("ui"));
+            });
+        }
         app_file_tree = render_template_file_tree_and_merge_with_existing(
             app_file_tree,
             &h,
-            web_app_template,
+            &web_app_template,
             &data,
         )?;
     }

--- a/src/templates/entry_type.rs
+++ b/src/templates/entry_type.rs
@@ -47,7 +47,6 @@ pub fn scaffold_entry_type_templates(
     let v: Vec<OsString> = field_types_path.iter().map(|s| s.to_os_string()).collect();
 
     if let Some(web_app_template) = template_file_tree.path(&mut v.iter()) {
-        // TODO: avoid cloning
         let mut web_app_template = web_app_template.clone();
         if no_ui {
             web_app_template.dir_content_mut().and_then(|v| {

--- a/src/templates/entry_type.rs
+++ b/src/templates/entry_type.rs
@@ -31,6 +31,7 @@ pub fn scaffold_entry_type_templates(
     entry_type: &EntryDefinition,
     crud: &Crud,
     link_from_original_to_each_update: bool,
+    no_ui: bool,
 ) -> ScaffoldResult<ScaffoldedTemplate> {
     let data = ScaffoldEntryTypeData {
         app_name: app_name.clone(),
@@ -46,10 +47,18 @@ pub fn scaffold_entry_type_templates(
     let v: Vec<OsString> = field_types_path.iter().map(|s| s.to_os_string()).collect();
 
     if let Some(web_app_template) = template_file_tree.path(&mut v.iter()) {
+        // TODO: avoid cloning
+        let mut web_app_template = web_app_template.clone();
+        if no_ui {
+            web_app_template.dir_content_mut().and_then(|v| {
+                v.retain(|k, _| k.ne(&OsString::from("ui")));
+                Some(v)
+            });
+        }
         app_file_tree = render_template_file_tree_and_merge_with_existing(
             app_file_tree,
             &h,
-            web_app_template,
+            &web_app_template,
             &data,
         )?;
     }

--- a/src/templates/helpers.rs
+++ b/src/templates/helpers.rs
@@ -7,10 +7,12 @@ use serde_json::Value;
 pub mod merge;
 pub mod uniq_lines;
 pub mod filter;
+pub mod file_exists;
 
 use merge::register_merge;
 use uniq_lines::register_uniq_lines;
 use filter::register_filter;
+use file_exists::register_file_exists;
 
 pub fn register_helpers<'a>(h: Handlebars<'a>) -> Handlebars<'a> {
     let h = register_concat_helper(h);
@@ -22,6 +24,7 @@ pub fn register_helpers<'a>(h: Handlebars<'a>) -> Handlebars<'a> {
     let h = register_merge(h);
     let h = register_uniq_lines(h);
     let h = register_filter(h);
+    let h = register_file_exists(h);
 
     h
 }

--- a/src/templates/helpers/file_exists.rs
+++ b/src/templates/helpers/file_exists.rs
@@ -36,7 +36,6 @@ impl HelperDef for FileExistsHelper {
         let needle = PathBuf::from(search_path_str);
         let needle = normalize_path(needle.as_path());
         let exists = file_exists(&ui_file_tree, &needle);
-				println!("needle: {needle:?}, exists: {exists:?}");
         Ok(ScopedJson::Derived(serde_json::Value::Bool(exists)))
     }
 }
@@ -92,19 +91,19 @@ mod tests {
     #[test]
     fn file_exists_with_existing_file() {
         let tempdir = std::env::temp_dir();
-				std::env::set_current_dir(&tempdir).unwrap();
+        std::env::set_current_dir(&tempdir).unwrap();
         let hbs = setup_handlebars();
         let tree: MergeableFileSystemTree<OsString, String> = dir! {
-						"ui" => dir! {
-							"bar.txt" => file!("{{#if (file_exists './foo.txt')}}file exists{{else}}does not exist{{/if}}"),
-							"foo.txt" => file!("")
-						}
+            "ui" => dir! {
+                "bar.txt" => file!("{{#if (file_exists './foo.txt')}}file exists{{else}}does not exist{{/if}}"),
+                "foo.txt" => file!("")
+            }
         }.into();
-				let v = PathBuf::from("ui")
-						.join("bar.txt")
-						.iter()
-						.map(|s| s.to_os_string())
-						.collect::<Vec<OsString>>();
+        let v = PathBuf::from("ui")
+            .join("bar.txt")
+            .iter()
+            .map(|s| s.to_os_string())
+            .collect::<Vec<OsString>>();
         let template = tree
             .path(&mut v.iter())
             .unwrap()
@@ -112,25 +111,25 @@ mod tests {
             .unwrap()
             .to_owned();
         tree.build(&tempdir).unwrap();
-				let value  = hbs.render_template(&template, &json!({})).unwrap();
-				assert_eq!(&value, "file exists");
+        let value = hbs.render_template(&template, &json!({})).unwrap();
+        assert_eq!(&value, "file exists");
     }
 
     #[test]
     fn file_exists_with_non_existing_file() {
         let tempdir = std::env::temp_dir();
-				std::env::set_current_dir(&tempdir).unwrap();
+        std::env::set_current_dir(&tempdir).unwrap();
         let hbs = setup_handlebars();
         let tree: MergeableFileSystemTree<OsString, String> = dir! {
-						"ui" => dir! {
-							"bar.txt" => file!("{{#if (file_exists './baz.txt')}}file exists{{else}}does not exist{{/if}}"),
-						}
+            "ui" => dir! {
+                "bar.txt" => file!("{{#if (file_exists './baz.txt')}}file exists{{else}}does not exist{{/if}}"),
+            }
         }.into();
-				let v = PathBuf::from("ui")
-						.join("bar.txt")
-						.iter()
-						.map(|s| s.to_os_string())
-						.collect::<Vec<OsString>>();
+        let v = PathBuf::from("ui")
+            .join("bar.txt")
+            .iter()
+            .map(|s| s.to_os_string())
+            .collect::<Vec<OsString>>();
         let template = tree
             .path(&mut v.iter())
             .unwrap()
@@ -138,7 +137,7 @@ mod tests {
             .unwrap()
             .to_owned();
         tree.build(&tempdir).unwrap();
-				let value  = hbs.render_template(&template, &json!({})).unwrap();
-				assert_eq!(&value, "does not exist");
+        let value = hbs.render_template(&template, &json!({})).unwrap();
+        assert_eq!(&value, "does not exist");
     }
 }

--- a/src/templates/helpers/file_exists.rs
+++ b/src/templates/helpers/file_exists.rs
@@ -36,6 +36,7 @@ impl HelperDef for FileExistsHelper {
         let needle = PathBuf::from(search_path_str);
         let needle = normalize_path(needle.as_path());
         let exists = file_exists(&ui_file_tree, &needle);
+				println!("needle: {needle:?}, exists: {exists:?}");
         Ok(ScopedJson::Derived(serde_json::Value::Bool(exists)))
     }
 }

--- a/src/templates/helpers/file_exists.rs
+++ b/src/templates/helpers/file_exists.rs
@@ -88,7 +88,7 @@ mod tests {
         hbs
     }
 
-		#[test]
+    #[test]
     fn file_exists_with_existing_file() {
         let tempdir = std::env::temp_dir();
 				std::env::set_current_dir(&tempdir).unwrap();
@@ -115,7 +115,7 @@ mod tests {
 				assert_eq!(&value, "file exists");
     }
 
-		#[test]
+    #[test]
     fn file_exists_with_non_existing_file() {
         let tempdir = std::env::temp_dir();
 				std::env::set_current_dir(&tempdir).unwrap();

--- a/src/templates/helpers/file_exists.rs
+++ b/src/templates/helpers/file_exists.rs
@@ -1,0 +1,74 @@
+use std::path::{Component, Path, PathBuf};
+
+use handlebars::{Handlebars, HelperDef, RenderError, ScopedJson};
+
+use crate::file_tree::{file_exists, load_directory_into_memory};
+
+#[derive(Clone, Copy)]
+/// A handlebars helper to check whether a given file exists in the current app file tree
+pub struct FileExistsHelper;
+
+impl HelperDef for FileExistsHelper {
+    fn call_inner<'reg: 'rc, 'rc>(
+        &self,
+        h: &handlebars::Helper<'reg, 'rc>,
+        r: &'reg handlebars::Handlebars<'reg>,
+        ctx: &'rc handlebars::Context,
+        _: &mut handlebars::RenderContext<'reg, 'rc>,
+    ) -> Result<handlebars::ScopedJson<'reg, 'rc>, handlebars::RenderError> {
+        let search_path_str = h
+            .params()
+            .iter()
+            .next()
+            .ok_or(RenderError::new("Missing search path param"))?
+            .value()
+            .to_string();
+        let data = ctx.data();
+        let search_path_str = r.render_template(&search_path_str, data)?.replace("\"", "");
+
+        let current_ui_dir = std::env::current_dir()
+            .map_err(|_| RenderError::new("current working dir is invalid"))?
+            .join("ui");
+
+        let ui_file_tree = load_directory_into_memory(&current_ui_dir)
+            .map_err(|_| RenderError::new("Faild to load directory into memory"))?;
+
+        let needle = PathBuf::from(search_path_str);
+        let needle = normalize_path(needle.as_path());
+        let exists = file_exists(&ui_file_tree, &needle);
+        Ok(ScopedJson::Derived(serde_json::Value::Bool(exists)))
+    }
+}
+
+pub fn register_file_exists<'a>(mut h: Handlebars<'a>) -> Handlebars<'a> {
+    h.register_helper("file_exists", Box::new(FileExistsHelper));
+
+    h
+}
+
+pub fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = path.components().peekable();
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!(),
+            Component::RootDir => {
+                ret.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
+            }
+        }
+    }
+    ret
+}

--- a/src/templates/link_type.rs
+++ b/src/templates/link_type.rs
@@ -54,7 +54,6 @@ pub fn scaffold_link_type_templates(
     let v: Vec<OsString> = link_type_path.iter().map(|s| s.to_os_string()).collect();
 
     if let Some(link_type_template) = template_file_tree.path(&mut v.iter()) {
-        // TODO: avoid cloning
         let mut link_type_template = link_type_template.clone();
         if no_ui {
             link_type_template.dir_content_mut().and_then(|v| {

--- a/src/templates/link_type.rs
+++ b/src/templates/link_type.rs
@@ -35,6 +35,7 @@ pub fn scaffold_link_type_templates(
     to_referenceable: &Option<Referenceable>,
     delete: bool,
     bidirectional: &Option<String>,
+    no_ui: bool,
 ) -> ScaffoldResult<ScaffoldedTemplate> {
     let data = ScaffoldLinkTypeData {
         app_name: app_name.clone(),
@@ -53,10 +54,18 @@ pub fn scaffold_link_type_templates(
     let v: Vec<OsString> = link_type_path.iter().map(|s| s.to_os_string()).collect();
 
     if let Some(link_type_template) = template_file_tree.path(&mut v.iter()) {
+        // TODO: avoid cloning
+        let mut link_type_template = link_type_template.clone();
+        if no_ui {
+            link_type_template.dir_content_mut().and_then(|v| {
+                v.retain(|k, _| k.ne(&OsString::from("ui")));
+                Some(v)
+            });
+        }
         app_file_tree = render_template_file_tree_and_merge_with_existing(
             app_file_tree,
             &h,
-            link_type_template,
+            &link_type_template,
             &data,
         )?;
     }

--- a/templates/lit/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case collection_name}}.ts.hbs
+++ b/templates/lit/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case collection_name}}.ts.hbs
@@ -46,7 +46,9 @@ export class {{pascal_case collection_name}} extends LitElement {
       if (signal.zome_name !== '{{coordinator_zome_manifest.name}}') return; 
       const payload = signal.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
       if (payload.type !== 'EntryCreated') return;
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case referenceable.name}}-detail.ts')}}
       if (payload.app_entry.type !== '{{pascal_case referenceable.name}}') return;
+{{/if}}
 {{#if (eq collection_type.type "ByAuthor")}}
       if (this.author.toString() !== this.client.myPubKey.toString()) return;
 {{/if}}
@@ -65,7 +67,7 @@ export class {{pascal_case collection_name}} extends LitElement {
           html`<{{kebab_case referenceable.name}}-detail .{{camel_case referenceable.name}}Hash=${hash} style="margin-bottom: 16px;" @{{kebab_case referenceable.name}}-deleted=${() => { this._fetch{{pascal_case (plural referenceable.name)}}.run(); this.signaledHashes = []; } }></{{kebab_case referenceable.name}}-detail>`
         )}
 {{else}}
-        <div style="margin-bottom: 16px">{{kebab_case to_referenceable.name}}-detail component generation was skipped</div>
+        <div style="margin-bottom: 16px">{{kebab_case referenceable.name}}-detail component generation was skipped</div>
 {{/if}}
       </div>
     `;

--- a/templates/lit/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case collection_name}}.ts.hbs
+++ b/templates/lit/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case collection_name}}.ts.hbs
@@ -8,20 +8,22 @@ import '@material/mwc-circular-progress';
 import { clientContext } from '../../contexts';
 import { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
 
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case referenceable.name}}-detail.ts')}}
 import './{{kebab_case referenceable.name}}-detail';
+{{/if}}
 
 @customElement('{{kebab_case collection_name}}')
 export class {{pascal_case collection_name}} extends LitElement {
   @consume({ context: clientContext })
   client!: AppAgentClient;
   
-  {{#if (eq collection_type.type "ByAuthor")}}
+{{#if (eq collection_type.type "ByAuthor")}}
   @property({
     hasChanged: (newVal: AgentPubKey, oldVal: AgentPubKey) => newVal?.toString() !== oldVal?.toString()
   })
   author!: AgentPubKey;
+{{/if}}
 
-  {{/if}}
   @state()
   signaledHashes: Array<{{referenceable.hash_type}}> = [];
   
@@ -34,12 +36,12 @@ export class {{pascal_case collection_name}} extends LitElement {
   }) as Promise<Array<Link>>, () => [{{#if (eq collection_type.type "ByAuthor")}}this.author{{/if}}]);
 
   firstUpdated() {
-  {{#if (eq collection_type.type "ByAuthor")}}
+{{#if (eq collection_type.type "ByAuthor")}}
     if (this.author === undefined) {
       throw new Error(`The author property is required for the {{kebab_case collection_name}} element`);
     }
+{{/if}}
 
-  {{/if}}
     this.client.on('signal', signal => {
       if (signal.zome_name !== '{{coordinator_zome_manifest.name}}') return; 
       const payload = signal.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
@@ -56,10 +58,15 @@ export class {{pascal_case collection_name}} extends LitElement {
     if (hashes.length === 0) return html`<span>No {{lower_case (plural referenceable.name)}} found{{#if (eq collection_type.type "ByAuthor")}} for this author{{/if}}.</span>`;
     
     return html`
+
       <div style="display: flex; flex-direction: column">
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case referenceable.name}}-detail.ts')}}
         ${hashes.map(hash => 
           html`<{{kebab_case referenceable.name}}-detail .{{camel_case referenceable.name}}Hash=${hash} style="margin-bottom: 16px;" @{{kebab_case referenceable.name}}-deleted=${() => { this._fetch{{pascal_case (plural referenceable.name)}}.run(); this.signaledHashes = []; } }></{{kebab_case referenceable.name}}-detail>`
         )}
+{{else}}
+        <div style="margin-bottom: 16px">{{kebab_case to_referenceable.name}}-detail component generation was skipped</div>
+{{/if}}
       </div>
     `;
   }

--- a/templates/lit/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{kebab_case (plural from_referenceable.name)}}-for-{{kebab_case to_referenceable.name}}.ts{{¡if}}.hbs
+++ b/templates/lit/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{kebab_case (plural from_referenceable.name)}}-for-{{kebab_case to_referenceable.name}}.ts{{¡if}}.hbs
@@ -7,7 +7,9 @@ import { clientContext } from '../../contexts';
 import { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
 
 import '@material/mwc-circular-progress';
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case from_referenceable.name}}-detail.ts')}}
 import './{{kebab_case from_referenceable.name}}-detail';
+{{/if}}
 
 @customElement('{{kebab_case (plural from_referenceable.name)}}-for-{{kebab_case to_referenceable.name}}')
 export class {{pascal_case (plural from_referenceable.name)}}For{{pascal_case to_referenceable.name}} extends LitElement {
@@ -50,9 +52,13 @@ export class {{pascal_case (plural from_referenceable.name)}}For{{pascal_case to
     
     return html`
       <div style="display: flex; flex-direction: column">
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case from_referenceable.name}}-detail.ts')}}
         ${hashes.map(hash => 
           html`<{{kebab_case from_referenceable.name}}-detail .{{camel_case from_referenceable.name}}Hash=${hash} style="margin-bottom: 16px;"></{{kebab_case from_referenceable.name}}-detail>`
         )}
+{{else}}
+      <div style="margin-bottom: 16px;">{{pascal_case to_referenceable.name}}-detail component generation was skipped</div>
+{{/if}}
       </div>
     `;
   }

--- a/templates/lit/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{kebab_case (plural from_referenceable.name)}}-for-{{kebab_case to_referenceable.name}}.ts{{¡if}}.hbs
+++ b/templates/lit/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{kebab_case (plural from_referenceable.name)}}-for-{{kebab_case to_referenceable.name}}.ts{{¡if}}.hbs
@@ -57,7 +57,7 @@ export class {{pascal_case (plural from_referenceable.name)}}For{{pascal_case to
           html`<{{kebab_case from_referenceable.name}}-detail .{{camel_case from_referenceable.name}}Hash=${hash} style="margin-bottom: 16px;"></{{kebab_case from_referenceable.name}}-detail>`
         )}
 {{else}}
-      <div style="margin-bottom: 16px;">{{pascal_case to_referenceable.name}}-detail component generation was skipped</div>
+      <div style="margin-bottom: 16px;">{{pascal_case from_referenceable.name}}-detail component generation was skipped</div>
 {{/if}}
       </div>
     `;

--- a/templates/lit/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and to_referenceable (ne to_referenceable.hash_type 'AgentPubKey'))}}{{kebab_case (plural to_referenceable.name)}}-for-{{kebab_case from_referenceable.name}}.ts{{¡if}}.hbs
+++ b/templates/lit/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and to_referenceable (ne to_referenceable.hash_type 'AgentPubKey'))}}{{kebab_case (plural to_referenceable.name)}}-for-{{kebab_case from_referenceable.name}}.ts{{¡if}}.hbs
@@ -6,7 +6,9 @@ import { Task } from '@lit-labs/task';
 import '@material/mwc-circular-progress';
 
 import { clientContext } from '../../contexts';
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case to_referenceable.name}}-detail.ts')}}
 import './{{kebab_case to_referenceable.name}}-detail';
+{{/if}}
 import { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
 
 @customElement('{{kebab_case (plural to_referenceable.name)}}-for-{{kebab_case from_referenceable.name}}')
@@ -50,9 +52,13 @@ export class {{pascal_case (plural to_referenceable.name)}}For{{pascal_case from
     
     return html`
       <div style="display: flex; flex-direction: column">
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case to_referenceable.name}}-detail.ts')}}
         ${hashes.map(hash => 
           html`<{{kebab_case to_referenceable.name}}-detail .{{camel_case to_referenceable.name}}Hash=${hash} style="margin-bottom: 16px;"></{{kebab_case to_referenceable.name}}-detail>`
         )}
+{{else}}
+      <div style="margin-bottom: 16px;">{{pascal_case to_referenceable.name}}-detail component generation was skipped</div>
+{{/if}}
       </div>
     `;
   }

--- a/templates/svelte/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case collection_name}}.svelte.hbs
+++ b/templates/svelte/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case collection_name}}.svelte.hbs
@@ -3,7 +3,9 @@ import { onMount, getContext } from 'svelte';
 import '@material/mwc-circular-progress';
 import type { EntryHash, Record, AgentPubKey, ActionHash, AppAgentClient, NewEntryAction } from '@holochain/client';
 import { clientContext } from '../../contexts';
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case referenceable.name}}Detail.svelte')}}
 import {{pascal_case referenceable.name}}Detail from './{{pascal_case referenceable.name}}Detail.svelte';
+{{/if}}
 import type { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
 
 {{#if (eq collection_type.type "ByAuthor")}}
@@ -31,7 +33,9 @@ onMount(async () => {
     if (signal.zome_name !== '{{coordinator_zome_manifest.name}}') return;
     const payload = signal.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
     if (payload.type !== 'EntryCreated') return;
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case referenceable.name}}Detail.svelte')}}
     if (payload.app_entry.type !== '{{pascal_case referenceable.name}}') return;
+{{/if}}
 {{#if (eq collection_type.type "ByAuthor")}}
     if (author.toString() !== client.myPubKey.toString()) return;
 {{/if}}
@@ -67,11 +71,15 @@ async function fetch{{pascal_case (plural referenceable.name)}}() {
 <span>No {{lower_case (plural referenceable.name)}} found{{#if (eq collection_type.type "ByAuthor")}} for this author{{/if}}.</span>
 {:else}
 <div style="display: flex; flex-direction: column">
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case referenceable.name}}Detail.svelte')}}
   {#each hashes as hash}
     <div style="margin-bottom: 8px;">
       <{{pascal_case referenceable.name}}Detail {{camel_case referenceable.name}}Hash={hash}  on:{{kebab_case referenceable.name}}-deleted={() => fetch{{pascal_case (plural referenceable.name)}}()}></{{pascal_case referenceable.name}}Detail>
     </div>
   {/each}
+{{else}}
+  <div style="margin-bottom: 8px">{{pascal_case referenceable.name}}Detail component generation was skipped</div>
+{{/if}}
 </div>
 {/if}
 

--- a/templates/svelte/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{pascal_case (plural from_referenceable.name)}}For{{pascal_case to_referenceable.name}}.svelte{{¡if}}.hbs
+++ b/templates/svelte/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{pascal_case (plural from_referenceable.name)}}For{{pascal_case to_referenceable.name}}.svelte{{¡if}}.hbs
@@ -3,7 +3,9 @@ import { onMount, getContext } from 'svelte';
 import '@material/mwc-circular-progress';
 import type { Link, Record, ActionHash, EntryHash, AgentPubKey, AppAgentClient, NewEntryAction } from '@holochain/client';
 import { clientContext } from '../../contexts';
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case from_referenceable.name}}Detail.svelte')}}
 import {{pascal_case from_referenceable.name}}Detail from './{{pascal_case from_referenceable.name}}Detail.svelte';
+{{/if}}
 import type { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
 
 export let {{camel_case to_referenceable.singular_arg}}: {{to_referenceable.hash_type}};
@@ -58,10 +60,14 @@ onMount(async () => {
 <span>No {{lower_case (plural from_referenceable.name)}} found for this {{lower_case to_referenceable.name}}.</span>
 {:else}
 <div style="display: flex; flex-direction: column">
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case from_referenceable.name}}Detail.svelte')}}
   {#each hashes as hash}
     <div style="margin-bottom: 8px;">
       <{{pascal_case from_referenceable.name}}Detail {{camel_case from_referenceable.name}}Hash={hash}></{{pascal_case from_referenceable.name}}Detail>
     </div>
   {/each}
+{{else}}
+  <div style="margin-bottom: 8px;">{{pascal_case from_referenceable.name}}Detail component generation was skipped</div>
+{{/if}}
 </div>
 {/if}

--- a/templates/svelte/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and to_referenceable (ne to_referenceable.hash_type 'AgentPubKey'))}}{{pascal_case (plural to_referenceable.name)}}For{{pascal_case from_referenceable.name}}.svelte{{¡if}}.hbs
+++ b/templates/svelte/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and to_referenceable (ne to_referenceable.hash_type 'AgentPubKey'))}}{{pascal_case (plural to_referenceable.name)}}For{{pascal_case from_referenceable.name}}.svelte{{¡if}}.hbs
@@ -3,7 +3,9 @@ import { onMount, getContext } from 'svelte';
 import '@material/mwc-circular-progress';
 import type { Record, EntryHash, ActionHash, AgentPubKey, AppAgentClient, NewEntryAction } from '@holochain/client';
 import { clientContext } from '../../contexts';
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case to_referenceable.name}}Detail.svelte')}}
 import {{pascal_case to_referenceable.name}}Detail from './{{pascal_case to_referenceable.name}}Detail.svelte';
+{{/if}}
 import type { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
 
 export let {{camel_case from_referenceable.singular_arg}}: {{from_referenceable.hash_type}};
@@ -58,10 +60,14 @@ onMount(async () => {
 <span>No {{lower_case (plural to_referenceable.name)}} found for this {{lower_case from_referenceable.name}}.</span>
 {:else}
 <div style="display: flex; flex-direction: column">
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case to_referenceable.name}}Detail.svelte')}}
   {#each hashes as hash}
     <div style="margin-bottom: 8px;">
       <{{pascal_case to_referenceable.name}}Detail {{camel_case to_referenceable.name}}Hash={hash}></{{pascal_case to_referenceable.name}}Detail>
     </div>
   {/each}
+{{else}}
+  <div style="margin-bottom: 8px;">{{pascal_case to_referenceable.name}}Detail component generation was skipped</div>
+{{/if}}
 </div>
 {/if}

--- a/templates/vue/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case collection_name}}.vue.hbs
+++ b/templates/vue/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case collection_name}}.vue.hbs
@@ -6,16 +6,16 @@
   <div v-else style="display: flex; flex-direction: column">
     <span v-if="error">Error fetching the {{lower_case (plural referenceable.name)}}: {{{{raw}}}} {{error.data}}.{{{{/raw}}}}</span>
     <div v-else-if="hashes && hashes.length > 0" style="margin-bottom: 8px">
-      {{#if (file_exists './{{pascal_case referenceable.name}}Detail.vue')}}
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case referenceable.name}}Detail.vue')}}
       <{{pascal_case referenceable.name}}Detail 
         v-for="hash in hashes" 
         :{{kebab_case referenceable.name}}-hash="hash"
         @{{kebab_case referenceable.name}}-deleted="fetch{{pascal_case referenceable.name}}()"
       >
       </{{pascal_case referenceable.name}}Detail>
-      {{else}}
-      <div>{{pascal_case referenceable.name}}Detail was not generated</div>
-      {{/if}}
+{{else}}
+      <div>{{pascal_case referenceable.name}}Detail component generation was skipped</div>
+{{/if}}
     </div>
     <span v-else>No {{lower_case (plural referenceable.name)}} found{{#if (eq collection_type.type "ByAuthor")}} for this author{{/if}}.</span>
   </div>
@@ -27,14 +27,14 @@ import { defineComponent, inject, toRaw, ComputedRef } from 'vue';
 import { decode } from '@msgpack/msgpack';
 import { AppAgentClient, NewEntryAction, Link, Record, AgentPubKey, EntryHash, ActionHash } from '@holochain/client';
 import '@material/mwc-circular-progress';
-{{#if (file_exists './{{pascal_case referenceable.name}}Detail.vue')}}
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case referenceable.name}}Detail.vue')}}
 import {{pascal_case referenceable.name}}Detail from './{{pascal_case referenceable.name}}Detail.vue';
 {{/if}}
 import { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
 
 export default defineComponent({
   components: {
-{{#if (file_exists './{{pascal_case referenceable.name}}Detail.vue')}}
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case referenceable.name}}Detail.vue')}}
     {{pascal_case referenceable.name}}Detail
 {{/if}}
   },
@@ -65,7 +65,7 @@ export default defineComponent({
       if (signal.zome_name !== '{{coordinator_zome_manifest.name}}') return; 
       const payload = signal.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
       if (payload.type !== 'EntryCreated') return;
-    {{#if (file_exists './{{pascal_case referenceable.name}}Detail.vue')}}
+    {{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case referenceable.name}}Detail.vue')}}
       if (payload.app_entry.type !== '{{pascal_case referenceable.name}}') return;
     {{/if}}
     {{#if (eq collection_type.type "ByAuthor")}}

--- a/templates/vue/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case collection_name}}.vue.hbs
+++ b/templates/vue/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case collection_name}}.vue.hbs
@@ -6,12 +6,16 @@
   <div v-else style="display: flex; flex-direction: column">
     <span v-if="error">Error fetching the {{lower_case (plural referenceable.name)}}: {{{{raw}}}} {{error.data}}.{{{{/raw}}}}</span>
     <div v-else-if="hashes && hashes.length > 0" style="margin-bottom: 8px">
+      {{#if (file_exists './{{pascal_case referenceable.name}}Detail.vue')}}
       <{{pascal_case referenceable.name}}Detail 
         v-for="hash in hashes" 
         :{{kebab_case referenceable.name}}-hash="hash"
         @{{kebab_case referenceable.name}}-deleted="fetch{{pascal_case referenceable.name}}()"
       >
       </{{pascal_case referenceable.name}}Detail>
+      {{else}}
+      <div>{{pascal_case referenceable.name}}Detail was not generated</div>
+      {{/if}}
     </div>
     <span v-else>No {{lower_case (plural referenceable.name)}} found{{#if (eq collection_type.type "ByAuthor")}} for this author{{/if}}.</span>
   </div>
@@ -23,12 +27,16 @@ import { defineComponent, inject, toRaw, ComputedRef } from 'vue';
 import { decode } from '@msgpack/msgpack';
 import { AppAgentClient, NewEntryAction, Link, Record, AgentPubKey, EntryHash, ActionHash } from '@holochain/client';
 import '@material/mwc-circular-progress';
+{{#if (file_exists './{{pascal_case referenceable.name}}Detail.vue')}}
 import {{pascal_case referenceable.name}}Detail from './{{pascal_case referenceable.name}}Detail.vue';
+{{/if}}
 import { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
 
 export default defineComponent({
   components: {
+{{#if (file_exists './{{pascal_case referenceable.name}}Detail.vue')}}
     {{pascal_case referenceable.name}}Detail
+{{/if}}
   },
 {{#if (eq collection_type.type "ByAuthor")}}
   props: {
@@ -57,10 +65,12 @@ export default defineComponent({
       if (signal.zome_name !== '{{coordinator_zome_manifest.name}}') return; 
       const payload = signal.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
       if (payload.type !== 'EntryCreated') return;
+    {{#if (file_exists './{{pascal_case referenceable.name}}Detail.vue')}}
       if (payload.app_entry.type !== '{{pascal_case referenceable.name}}') return;
-{{#if (eq collection_type.type "ByAuthor")}}
+    {{/if}}
+    {{#if (eq collection_type.type "ByAuthor")}}
       if (this.author.toString() !== this.client.myPubKey.toString()) return;
-{{/if}}
+    {{/if}}
       if (this.hashes) this.hashes.push({{#if (eq referenceable.hash_type "ActionHash")}}payload.action.hashed.hash{{else}}(payload.action.hashed.content as NewEntryAction).entry_hash{{/if}});
     });
   },

--- a/templates/vue/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{pascal_case (plural from_referenceable.name)}}For{{pascal_case to_referenceable.name}}.vue{{¡if}}.hbs
+++ b/templates/vue/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{pascal_case (plural from_referenceable.name)}}For{{pascal_case to_referenceable.name}}.vue{{¡if}}.hbs
@@ -6,10 +6,14 @@
   <div v-else style="display: flex; flex-direction: column">
     <span v-if="error">Error fetching the {{lower_case (plural from_referenceable.name)}}: {{{{raw}}}} {{error.data}}.{{{{/raw}}}}</span>
     <div v-else-if="hashes && hashes.length > 0" style="margin-bottom: 8px">
+{{#if (file_exists './{{pascal_case from_referenceable.name}}Detail.vue')}}
       <{{pascal_case from_referenceable.name}}Detail 
         v-for="hash in hashes" 
         :{{kebab_case from_referenceable.name}}-hash="hash" 
       ></{{pascal_case from_referenceable.name}}Detail>
+{{else}}
+      <div>{{pascal_case from_referenceable.name}}Detail component generation was skipped</div>
+{{/if}}
     </div>
     <span v-else>No {{lower_case (plural from_referenceable.name)}} found for this {{lower_case to_referenceable.name}}.</span>
   </div>
@@ -21,12 +25,16 @@ import { defineComponent, toRaw, inject, ComputedRef } from 'vue';
 import { decode } from '@msgpack/msgpack';
 import { Link, AppAgentClient, Record, AgentPubKey, EntryHash, ActionHash, NewEntryAction } from '@holochain/client';
 import '@material/mwc-circular-progress';
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case from_referenceable.name}}Detail.vue')}}
 import {{pascal_case from_referenceable.name}}Detail from './{{pascal_case from_referenceable.name}}Detail.vue';
+{{/if}}
 import { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
 
 export default defineComponent({
   components: {
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case from_referenceable.name}}Detail.vue')}}
     {{pascal_case from_referenceable.name}}Detail
+{{/if}}
   },
   props: {
     {{camel_case to_referenceable.singular_arg}}: {

--- a/templates/vue/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and to_referenceable (ne to_referenceable.hash_type 'AgentPubKey'))}}{{pascal_case (plural to_referenceable.name)}}For{{pascal_case from_referenceable.name}}.vue{{¡if}}.hbs
+++ b/templates/vue/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and to_referenceable (ne to_referenceable.hash_type 'AgentPubKey'))}}{{pascal_case (plural to_referenceable.name)}}For{{pascal_case from_referenceable.name}}.vue{{¡if}}.hbs
@@ -6,10 +6,14 @@
   <div v-else style="display: flex; flex-direction: column">
     <span v-if="error">Error fetching the {{lower_case (plural to_referenceable.name)}}: {{{{raw}}}} {{error.data}}.{{{{/raw}}}}</span>
     <div v-else-if="hashes && hashes.length > 0" style="margin-bottom: 8px">
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case to_referenceable.name}}Detail.vue')}}
       <{{pascal_case to_referenceable.name}}Detail 
         v-for="hash in hashes" 
         :{{kebab_case to_referenceable.name}}-hash="hash" 
       ></{{pascal_case to_referenceable.name}}Detail>
+{{else}}
+      <div>{{pascal_case to_referenceable.name}}Detail component generation was skipped</div>
+{{/if}}
     </div>
     <span v-else>No {{lower_case (plural to_referenceable.name)}} found for this {{lower_case from_referenceable.name}}.</span>
   </div>
@@ -22,12 +26,16 @@ import { defineComponent, toRaw, inject, ComputedRef } from 'vue';
 import { decode } from '@msgpack/msgpack';
 import { AppAgentClient, Record, Link, AgentPubKey, EntryHash, ActionHash, NewEntryAction } from '@holochain/client';
 import '@material/mwc-circular-progress';
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case to_referenceable.name}}Detail.vue')}}
 import {{pascal_case to_referenceable.name}}Detail from './{{pascal_case to_referenceable.name}}Detail.vue';
+{{/if}}
 import { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
 
 export default defineComponent({
   components: {
+{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case to_referenceable.name}}Detail.vue')}}
     {{pascal_case to_referenceable.name}}Detail
+{{/if}}
   },
   props: {
     {{camel_case from_referenceable.singular_arg}}: {


### PR DESCRIPTION
This adds an optional flag `--no-ui` for the `link-type`, `entry-type` and `collection` commands. This flag skips `ui` generation, though the `tests` folder will still be populated with generated code

This change is non intrusive and does not break the normal behaviour of these commands

closes #186 