### PR TITLE
chore: update holochain client version

### DIFF
--- a/src/versions.rs
+++ b/src/versions.rs
@@ -3,7 +3,7 @@ pub fn tryorama_version() -> String {
 }
 
 pub fn holochain_client_version() -> String {
-    String::from("^0.17.0-dev.3")
+    String::from("^0.17.0-dev.5")
 }
 
 // TODO: update to 0.3 compatible version


### PR DESCRIPTION
This PR updates the holochain client version to the latest `0.3` compatible version that addresses `cell_id` being a proxy object

https://github.com/holochain/holochain-client-js/releases/tag/v0.17.0-dev.5