### PR TITLE
Adds holochain_client_version variable to example package.json

### DIFF
--- a/templates/vanilla/example/ui/package.json.hbs
+++ b/templates/vanilla/example/ui/package.json.hbs
@@ -9,7 +9,7 @@
       "package": "npm run build && cd dist && bestzip ../dist.zip *"
     },
     "dependencies": {
-      "@holochain/client": "^0.12.2",
+      "@holochain/client": "{{holochain_client_version}}",
       "@holo-host/identicon": "^0.1.0",
       "@msgpack/msgpack": "^2.7.2"
     },


### PR DESCRIPTION
I haven't actually tested it yet but I'm assuming the example package.json.hbs has access to the `holochain_client_version` variable as well. 