### PR TITLE
fix: extend example template data struct

### DIFF
--- a/src/templates/example.rs
+++ b/src/templates/example.rs
@@ -4,7 +4,7 @@ use std::{ffi::OsString, path::PathBuf};
 use crate::{
     error::ScaffoldResult,
     file_tree::{file_content, FileTree},
-    scaffold::example::Example,
+    scaffold::example::Example, versions::{hdi_version, hdk_version, holochain_client_version},
 };
 
 use super::{
@@ -14,6 +14,9 @@ use super::{
 #[derive(Serialize)]
 pub struct ScaffoldExampleData {
     pub example: String,
+    pub holochain_client_version: String,
+    pub hdk_version: String,
+    pub hdi_version: String,
 }
 
 pub fn scaffold_example(
@@ -23,6 +26,9 @@ pub fn scaffold_example(
 ) -> ScaffoldResult<ScaffoldedTemplate> {
     let data = ScaffoldExampleData {
         example: example.to_string(),
+        holochain_client_version: holochain_client_version(),
+        hdk_version: hdk_version(),
+        hdi_version: hdi_version(),
     };
     let h = build_handlebars(&template_file_tree)?;
 

--- a/templates/vanilla/example/Cargo.toml.hbs
+++ b/templates/vanilla/example/Cargo.toml.hbs
@@ -9,9 +9,9 @@ members = ["dnas/*/zomes/coordinator/*", "dnas/*/zomes/integrity/*"]
 resolver = "2"
 
 [workspace.dependencies]
-hdi = "=0.4.0-beta-dev.24"
-hdk = "=0.3.0-beta-dev.28"
-serde = "1.0.195"
+hdi = "={{hdi_version}}"
+hdk = "={{hdk_version}}"
+serde = "1.0"
 
 [workspace.dependencies.hello_world]
 path = "dnas/hello_world/zomes/coordinator/hello_world"


### PR DESCRIPTION
This PR extends the `ExampleTemplateData` struct that is provided to the example templates to include dependency versions, unblocks #207 