### PR TITLE
fix: add reserved word check for entry-type field name

### DIFF
--- a/src/scaffold/entry_type/definitions.rs
+++ b/src/scaffold/entry_type/definitions.rs
@@ -5,6 +5,7 @@ use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 
 use crate::{
     error::{ScaffoldError, ScaffoldResult},
+    reserved_words::check_for_reserved_words,
     utils::check_case,
 };
 
@@ -158,6 +159,25 @@ pub struct FieldDefinition {
     pub widget: Option<String>,
     pub cardinality: Cardinality,
     pub linked_from: Option<Referenceable>,
+}
+
+impl FieldDefinition {
+    pub fn new(
+        field_name: String,
+        field_type: FieldType,
+        widget: Option<String>,
+        cardinality: Cardinality,
+        linked_from: Option<Referenceable>,
+    ) -> Result<Self, ScaffoldError> {
+        check_for_reserved_words(&field_name)?;
+        Ok(FieldDefinition {
+            field_name,
+            field_type,
+            widget,
+            cardinality,
+            linked_from,
+        })
+    }
 }
 
 impl FieldDefinition {

--- a/src/scaffold/entry_type/fields.rs
+++ b/src/scaffold/entry_type/fields.rs
@@ -331,13 +331,13 @@ pub fn choose_field(
         choose_widget(&field_type, field_types_templates)?
     };
 
-    Ok(FieldDefinition {
-        widget,
+    FieldDefinition::new(
         field_name,
-        cardinality,
         field_type,
-        linked_from: maybe_linked_from,
-    })
+        widget,
+        cardinality,
+        maybe_linked_from,
+    )
 }
 
 pub fn choose_fields(


### PR DESCRIPTION
This PR adds a missing check for reserved Rust keywords for entry type fields

This fixes [#2679](https://github.com/holochain/holochain/issues/2769) from the holochain repo

Attempting to use a reserved keyword such as `type` now results in a more useful error

```shell
➜ hc-scaffold entry-type agent_role

Which fields should the entry contain?

✔ Choose field type: · Enum
✔ Enter the name of the enum: · AgentRoleName
✔ Enter the name of the next variant: · Admin
✔ Enter the name of the next variant: · Staff
✔ Field name: · name
✔ Should this field be visible in the UI? · yes
✔ Choose widget to render this field: · Select

✔ Choose field type: · Enum
✔ Enter the name of the enum: · AgentRoleType
✔ Enter the name of the next variant: · Swap
✔ Enter the name of the next variant: · Provider
✔ Enter the name of the next variant: · Nrkl
✔ Field name: · type
✔ Should this field be visible in the UI? · yes
✔ Choose widget to render this field: · Select
Error: Invalid reserved word: type
```