### PR TITLE
Update holochain source

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710852754,
-        "narHash": "sha256-SOLQaEm17wIWIA4l9uAZ06tKcM84pMtJtVUQofKiDeU=",
+        "lastModified": 1710946843,
+        "narHash": "sha256-hACtlQxJcx6niex/ohNP3Ikz7uGKeFfbfuca0HARinU=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "ddeb601b7276db57990a76defbb2966229cc6f3d",
+        "rev": "c6c26b26950637c5654e64e0caf447a60ea90331",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710631334,
-        "narHash": "sha256-rL5LSYd85kplL5othxK5lmAtjyMOBg390sGBTb3LRMM=",
+        "lastModified": 1710806803,
+        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c75037bbf9093a2acb617804ee46320d6d1fea5a",
+        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710814282,
-        "narHash": "sha256-nWaKhMQackiO0M8504HSx/E7I76C2r0/g4wqZf4hp24=",
+        "lastModified": 1710900660,
+        "narHash": "sha256-PcHmHQvKIOdvAxlqxZ/DPmUMhUUvfp16pRtyW148u/0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8c72f33c23c8e537dd59088c4560222c43eedaca",
+        "rev": "549f4db17b5c0c143b1308fcfe9620129c387472",
         "type": "github"
       },
       "original": {
@@ -348,11 +348,11 @@
     "scaffolding": {
       "flake": false,
       "locked": {
-        "lastModified": 1710798431,
-        "narHash": "sha256-bKrJo25rGGxgq7hgpEbx9ATBkfTsuNdj9DuRrD7bWSQ=",
+        "lastModified": 1710940024,
+        "narHash": "sha256-mqeNMRinG7P4S29pLOshgnR3KK+dF3xAfLEdJ7ND3PI=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "2524ee6d1cdd9ff09223f80601b23473a8b279cd",
+        "rev": "dbb2dac72e6668f1198fefc70003b231a9e84b4e",
         "type": "github"
       },
       "original": {
@@ -386,11 +386,11 @@
       },
       "locked": {
         "dir": "versions/weekly",
-        "lastModified": 1710852754,
-        "narHash": "sha256-SOLQaEm17wIWIA4l9uAZ06tKcM84pMtJtVUQofKiDeU=",
+        "lastModified": 1710946843,
+        "narHash": "sha256-hACtlQxJcx6niex/ohNP3Ikz7uGKeFfbfuca0HARinU=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "ddeb601b7276db57990a76defbb2966229cc6f3d",
+        "rev": "c6c26b26950637c5654e64e0caf447a60ea90331",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
I just run `nix flake update`, this unblocks the testing of custom templates with the new nix infrastructure.