### PR TITLE
chore: Update templates

### DIFF
--- a/templates/custom-template/custom-template/template/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case collection_name}}.ts.hbs
+++ b/templates/custom-template/custom-template/template/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case collection_name}}.ts.hbs
@@ -8,9 +8,7 @@ import '@material/mwc-circular-progress';
 import { clientContext } from '../../contexts';
 import { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
 
-{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case referenceable.name}}-detail.ts')}}
 import './{{kebab_case referenceable.name}}-detail';
-{{/if}}
 
 @customElement('{{kebab_case collection_name}}')
 export class {{pascal_case collection_name}} extends LitElement {
@@ -46,9 +44,7 @@ export class {{pascal_case collection_name}} extends LitElement {
       if (signal.zome_name !== '{{coordinator_zome_manifest.name}}') return; 
       const payload = signal.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
       if (payload.type !== 'EntryCreated') return;
-{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case referenceable.name}}-detail.ts')}}
       if (payload.app_entry.type !== '{{pascal_case referenceable.name}}') return;
-{{/if}}
 {{#if (eq collection_type.type "ByAuthor")}}
       if (this.author.toString() !== this.client.myPubKey.toString()) return;
 {{/if}}
@@ -62,13 +58,9 @@ export class {{pascal_case collection_name}} extends LitElement {
     return html`
 
       <div style="display: flex; flex-direction: column">
-{{#if (file_exists 'src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case referenceable.name}}-detail.ts')}}
         ${hashes.map(hash => 
           html`<{{kebab_case referenceable.name}}-detail .{{camel_case referenceable.name}}Hash=${hash} style="margin-bottom: 16px;" @{{kebab_case referenceable.name}}-deleted=${() => { this._fetch{{pascal_case (plural referenceable.name)}}.run(); this.signaledHashes = []; } }></{{kebab_case referenceable.name}}-detail>`
         )}
-{{else}}
-        <div style="margin-bottom: 16px">{{kebab_case referenceable.name}}-detail component generation was skipped</div>
-{{/if}}
       </div>
     `;
   }

--- a/templates/vue/web-app/package.json.hbs
+++ b/templates/vue/web-app/package.json.hbs
@@ -17,7 +17,6 @@
     "start:holo": "AGENTS=${AGENTS:-2} npm run network:holo",
     "network:holo": "npm run build:happ && UI_PORT=$(port) concurrently \"npm run launch:holo-dev-server\" \"holochain-playground ws://localhost:4444\" \"concurrently-repeat 'VITE_APP_CHAPERONE_URL=http://localhost:24274 VITE_APP_IS_HOLO=true npm start -w ui' $AGENTS\"",
     "launch:holo-dev-server": "holo-dev-server workdir/{{app_name}}.happ",
-    "package:holo": "npm run build:happ && npm run package:holo -w ui && hc web-app pack workdirk --recursive",
   {{/if}}
     "package": "npm run build:happ && npm run package -w ui && hc web-app pack workdir --recursive",
     "build:happ": "npm run build:zomes && hc app pack workdir --recursive",


### PR DESCRIPTION
This PR removes traces of the `file_exists` helper from the `custom-template` and the redundant `package:holo` script left over from #251 