### PR TITLE
fix: prevent unaffected rust files from getting formatted

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -177,5 +177,5 @@ pub fn check_no_whitespace(input: &str, identifier: &str) -> ScaffoldResult<()> 
 }
 
 pub fn unparse(file: &syn::File) -> String {
-    prettyplease::unparse(file).replace("///", "//")
+    prettyplease::unparse(file)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -177,5 +177,5 @@ pub fn check_no_whitespace(input: &str, identifier: &str) -> ScaffoldResult<()> 
 }
 
 pub fn unparse(file: &syn::File) -> String {
-    prettyplease::unparse(file)
+    prettyplease::unparse(file).replace("///", "//")
 }


### PR DESCRIPTION
This PR fixes #261

With regards to the scaffolding tool removing comments, I think it's easier if this is tackled in a separate PR. I have re-opened the original issue to keep track of it as well #167 since the root cause is now known.