### PR TITLE
Add fix to prevent accumulation of dist.zip content

### DIFF
--- a/templates/custom-template/custom-template/template/web-app/ui/package.json.hbs
+++ b/templates/custom-template/custom-template/template/web-app/ui/package.json.hbs
@@ -6,11 +6,11 @@
     "build": "vite build",
   {{#if holo_enabled}}
     "build:holo": "VITE_APP_IS_HOLO=true vite build",
-    "package:holo": "npm run build:holo && cd dist && bestzip ../dist.zip *",
+    "package:holo": "npm run build:holo && rimraf dist.zip && cd dist && bestzip ../dist.zip *",
   {{/if}}
     "lint": "eslint --ext .ts,.html . --ignore-path .gitignore && prettier \"**/*.ts\" --check --ignore-path .gitignore",
     "format": "eslint --ext .ts,.html . --fix --ignore-path .gitignore && prettier \"**/*.ts\" --write --ignore-path .gitignore",
-    "package": "npm run build && cd dist && bestzip ../dist.zip *"
+    "package": "npm run build && rimraf dist.zip && cd dist && bestzip ../dist.zip *"
   },
   "dependencies": {
     "@holochain/client": "{{holochain_client_version}}",

--- a/templates/lit/web-app/ui/package.json.hbs
+++ b/templates/lit/web-app/ui/package.json.hbs
@@ -6,11 +6,11 @@
     "build": "vite build",
   {{#if holo_enabled}}
     "build:holo": "VITE_APP_IS_HOLO=true vite build",
-    "package:holo": "npm run build:holo && cd dist && bestzip ../dist.zip *",
+    "package:holo": "npm run build:holo && rimraf dist.zip && cd dist && bestzip ../dist.zip *",
   {{/if}}
     "lint": "eslint --ext .ts,.html . --ignore-path .gitignore && prettier \"**/*.ts\" --check --ignore-path .gitignore",
     "format": "eslint --ext .ts,.html . --fix --ignore-path .gitignore && prettier \"**/*.ts\" --write --ignore-path .gitignore",
-    "package": "npm run build && cd dist && bestzip ../dist.zip *"
+    "package": "npm run build && rimraf dist.zip && cd dist && bestzip ../dist.zip *"
   },
   "dependencies": {
     "@holochain/client": "{{holochain_client_version}}",

--- a/templates/svelte/web-app/ui/package.json.hbs
+++ b/templates/svelte/web-app/ui/package.json.hbs
@@ -6,10 +6,10 @@
     "build": "npm run check && vite build",
   {{#if holo_enabled}}
     "build:holo": "VITE_APP_IS_HOLO=true vite build",
-    "package:holo": "npm run build:holo && cd dist && bestzip ../dist.zip *",
+    "package:holo": "npm run build:holo && rimraf dist.zip && cd dist && bestzip ../dist.zip *",
   {{/if}}
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "package": "npm run build && cd dist && bestzip ../dist.zip *"
+    "package": "npm run build && rimraf dist.zip && cd dist && bestzip ../dist.zip *"
   },
   "dependencies": {
     "@holochain/client": "{{holochain_client_version}}",
@@ -33,6 +33,7 @@
     "@sveltejs/vite-plugin-svelte": "^2.0.2",
     "@tsconfig/svelte": "^3.0.0",
     "bestzip": "^2.2.0",
+    "rimraf": "^3.0.2",
     "svelte": "^3.55.1",
     "svelte-check": "^2.10.3",
     "tslib": "^2.4.1",

--- a/templates/vanilla/example/ui/package.json.hbs
+++ b/templates/vanilla/example/ui/package.json.hbs
@@ -6,7 +6,7 @@
     "scripts": {
       "start": "vite --clearScreen false --port $UI_PORT",
       "build": "vite build",
-      "package": "npm run build && cd dist && bestzip ../dist.zip *"
+      "package": "npm run build && rimraf dist.zip && cd dist && bestzip ../dist.zip *"
     },
     "dependencies": {
       "@holochain/client": "{{holochain_client_version}}",

--- a/templates/vanilla/web-app/ui/package.json.hbs
+++ b/templates/vanilla/web-app/ui/package.json.hbs
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "vite --clearScreen false --port $UI_PORT",
     "build": "vite build",
-    "package": "npm run build && cd dist && bestzip ../dist.zip *"
+    "package": "npm run build && rimraf dist.zip && cd dist && bestzip ../dist.zip *"
   },
   "dependencies": {
     "@holochain/client": "{{holochain_client_version}}",

--- a/templates/vue/web-app/ui/package.json.hbs
+++ b/templates/vue/web-app/ui/package.json.hbs
@@ -6,11 +6,11 @@
     "build": "npm run check && vite build",
   {{#if holo_enabled}}
     "build:holo": "VITE_APP_IS_HOLO=true vite build",
-    "package:holo": "npm run build:holo && cd dist && bestzip ../dist.zip *",
+    "package:holo": "npm run build:holo && rimraf dist.zip && cd dist && bestzip ../dist.zip *",
   {{/if}}
     "check": "vue-tsc --noEmit",
     "preview": "vite preview",
-    "package": "npm run build && cd dist && bestzip ../dist.zip *"
+    "package": "npm run build && rimraf dist.zip && cd dist && bestzip ../dist.zip *"
   },
   "dependencies": {
     "@holochain/client": "{{holochain_client_version}}",
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.0.0",
     "bestzip": "^2.2.0",
+    "rimraf": "^3.0.2",
     "typescript": "^4.9.3",
     "vite": "^4.0.4",
     "vite-plugin-checker": "^0.5.1",


### PR DESCRIPTION
I should have added this a long time ago. It turns out that the `dist.zip` file keeps accumulating in size with each `npm run package` step if it is not being removed before packaging (presumably because bestzip does not overwrite the dist.zip file and if files in the dist folder get renamed they are simply added to the archive). That way webhapps can grow to humongous sizes over time without the developer being aware of it.