### PR TITLE
fix: Update lit templates

### DIFF
--- a/templates/custom-template/custom-template/template/field-types/Timestamp/DateTimePicker/edit/render.hbs
+++ b/templates/custom-template/custom-template/template/field-types/Timestamp/DateTimePicker/edit/render.hbs
@@ -1,2 +1,1 @@
-<vaadin-date-time-picker label="{{label}}" {{#if variable_to_read}}.value=${new Date({{variable_to_read}} / 1000).toISOString()}{{/if}} @input=${(e: CustomEvent) => { {{variable_to_change}} = new Date((e.target as any).value).valueOf() * 1000;} } {{#if required}}required{{/if}}></vaadin-date-time-picker>
-
+<vaadin-date-time-picker label="{{label}}" {{#if variable_to_read}}.value=${new Date({{variable_to_read}} / 1000).toISOString()}{{/if}} @change=${(e: CustomEvent) => { {{variable_to_change}} = new Date((e.target as any).value).valueOf() * 1000;} } {{#if required}}required{{/if}}></vaadin-date-time-picker>

--- a/templates/custom-template/custom-template/template/field-types/Timestamp/DateTimePicker/edit/render.hbs
+++ b/templates/custom-template/custom-template/template/field-types/Timestamp/DateTimePicker/edit/render.hbs
@@ -1,2 +1,2 @@
-<vaadin-date-time-picker label="{{label}}" {{#if variable_to_read}}.value=${new Date({{variable_to_read}} / 1000).toISOString()}{{/if}} @change=${(e: CustomEvent) => { {{variable_to_change}} = new Date((e.target as any).value).valueOf() * 1000;} } {{#if required}}required{{/if}}></vaadin-date-time-picker>
+<vaadin-date-time-picker label="{{label}}" {{#if variable_to_read}}.value=${new Date({{variable_to_read}} / 1000).toISOString()}{{/if}} @input=${(e: CustomEvent) => { {{variable_to_change}} = new Date((e.target as any).value).valueOf() * 1000;} } {{#if required}}required{{/if}}></vaadin-date-time-picker>
 

--- a/templates/custom-template/custom-template/template/field-types/Vec/edit/render.hbs
+++ b/templates/custom-template/custom-template/template/field-types/Vec/edit/render.hbs
@@ -1,4 +1,4 @@
-<div style="display: flex; flex-direction: column" @input=${() => this.requestUpdate()} @input=${() => this.requestUpdate()}>
+<div style="display: flex; flex-direction: column" @input=${() => this.requestUpdate()} @change=${() => this.requestUpdate()}>
   <span>{{title_case field_name}}</span>
 
   ${this._{{camel_case field_name}}.map((el, i) => html`{{> (concat field_type.type "/" widget "/edit/render") label="" variable_to_read="el" variable_to_change=(concat "this._" (camel_case field_name) "[i]" ) }} }`)}

--- a/templates/custom-template/custom-template/template/field-types/Vec/edit/render.hbs
+++ b/templates/custom-template/custom-template/template/field-types/Vec/edit/render.hbs
@@ -1,6 +1,6 @@
-<div style="display: flex; flex-direction: column" @input=${() => this.requestUpdate()} @change=${() => this.requestUpdate()}>
+<div style="display: flex; flex-direction: column" @input=${() => this.requestUpdate()} @input=${() => this.requestUpdate()}>
   <span>{{title_case field_name}}</span>
-  
+
   ${this._{{camel_case field_name}}.map((el, i) => html`{{> (concat field_type.type "/" widget "/edit/render") label="" variable_to_read="el" variable_to_change=(concat "this._" (camel_case field_name) "[i]" ) }} }`)}
   <mwc-button icon="add" label="Add {{title_case field_name}}" @click=${() => { this._{{camel_case field_name}} = [...this._{{camel_case field_name}}, {{> (concat field_type.type "/" widget "/initial-value") field_type=field_type}}]; } }></mwc-button>
 </div>

--- a/templates/custom-template/custom-template/template/field-types/bool/Checkbox/edit/render.hbs
+++ b/templates/custom-template/custom-template/template/field-types/bool/Checkbox/edit/render.hbs
@@ -1,3 +1,3 @@
 <mwc-formfield label="{{label}}">
-  <mwc-checkbox .checked=${ {{variable_to_read}} } @change=${(e: CustomEvent) => { {{variable_to_change}} = (e.target as any).checked;} }></mwc-checkbox>
+  <mwc-checkbox .checked=${ {{variable_to_read}} } @input=${(e: CustomEvent) => { {{variable_to_change}} = (e.target as any).checked;} }></mwc-checkbox>
 </mwc-formfield>

--- a/templates/custom-template/custom-template/template/field-types/bool/Checkbox/edit/render.hbs
+++ b/templates/custom-template/custom-template/template/field-types/bool/Checkbox/edit/render.hbs
@@ -1,3 +1,3 @@
 <mwc-formfield label="{{label}}">
-  <mwc-checkbox .checked=${ {{variable_to_read}} } @input=${(e: CustomEvent) => { {{variable_to_change}} = (e.target as any).checked;} }></mwc-checkbox>
+  <mwc-checkbox .checked=${ {{variable_to_read}} } @change=${(e: CustomEvent) => { {{variable_to_change}} = (e.target as any).checked;} }></mwc-checkbox>
 </mwc-formfield>

--- a/templates/ui-frameworks/lit/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case collection_name}}.ts.hbs
+++ b/templates/ui-frameworks/lit/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{kebab_case collection_name}}.ts.hbs
@@ -40,7 +40,7 @@ export class {{pascal_case collection_name}} extends LitElement {
     }
 {{/if}}
 
-    this.client.on('signal', signal => {
+    this.client?.on('signal', signal => {
       if (!(SignalType.App in signal)) return;
       if (signal.App.zome_name !== '{{coordinator_zome_manifest.name}}') return;
       const payload = signal.App.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;

--- a/templates/ui-frameworks/lit/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{kebab_case (plural ..¡entry_type.name)}}-for-{{kebab_case linked_from.name}}.ts{{¡if}}{{¡each}}.hbs
+++ b/templates/ui-frameworks/lit/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{kebab_case (plural ..¡entry_type.name)}}-for-{{kebab_case linked_from.name}}.ts{{¡if}}{{¡each}}.hbs
@@ -36,7 +36,7 @@ export class {{pascal_case (plural ../entry_type.name)}}For{{pascal_case linked_
       throw new Error(`The {{camel_case linked_from.singular_arg}} property is required for the {{kebab_case (plural ../entry_type.name)}}-for-{{kebab_case linked_from.name}} element`);
     }
 
-    this.client.on('signal', signal => {
+    this.client?.on('signal', signal => {
       if (!(SignalType.App in signal)) return;
       if (signal.App.zome_name !== '{{../coordinator_zome_manifest.name}}') return;
       const payload = signal.App.payload as {{pascal_case ../coordinator_zome_manifest.name}}Signal;

--- a/templates/ui-frameworks/lit/field-types/Enum/Select/edit/render.hbs
+++ b/templates/ui-frameworks/lit/field-types/Enum/Select/edit/render.hbs
@@ -1,5 +1,5 @@
 <label for="{{label}}">{{label}}:</label>
-<select name="{{label}}" @change=${ (e: any) => { this._{{variable_to_change}} = e.target.value; } }>
+<select name="{{label}}" @input=${ (e: any) => { {{variable_to_change}} = e.target.value; } }>
 {{#each field_type.variants}}
   <option ?selected=${ {{../variable_to_read}}.type === '{{pascal_case this}}' } value="{{this}}">
     {{title_case this}}

--- a/templates/ui-frameworks/lit/field-types/Enum/Select/edit/render.hbs
+++ b/templates/ui-frameworks/lit/field-types/Enum/Select/edit/render.hbs
@@ -1,5 +1,5 @@
 <label for="{{label}}">{{label}}:</label>
-<select name="{{label}}" @input=${ (e: any) => { {{variable_to_change}} = { type: e.target.value }; } }>
+<select name="{{label}}" @change=${ (e: any) => { {{variable_to_change}} = { type: e.target.value }; } }>
 {{#each field_type.variants}}
   <option ?selected=${ {{../variable_to_read}}.type === '{{pascal_case this}}' } value="{{this}}">
     {{title_case this}}

--- a/templates/ui-frameworks/lit/field-types/Enum/Select/edit/render.hbs
+++ b/templates/ui-frameworks/lit/field-types/Enum/Select/edit/render.hbs
@@ -1,5 +1,5 @@
 <label for="{{label}}">{{label}}:</label>
-<select name="{{label}}" @input=${ (e: any) => { {{variable_to_change}} = e.target.value; } }>
+<select name="{{label}}" @input=${ (e: any) => { {{variable_to_change}} = { type: e.target.value }; } }>
 {{#each field_type.variants}}
   <option ?selected=${ {{../variable_to_read}}.type === '{{pascal_case this}}' } value="{{this}}">
     {{title_case this}}

--- a/templates/ui-frameworks/lit/field-types/String/TextArea/edit/render.hbs
+++ b/templates/ui-frameworks/lit/field-types/String/TextArea/edit/render.hbs
@@ -4,7 +4,7 @@
   {{#if variable_to_read}}
   .value=${ {{variable_to_read}} }
   {{/if}}
-  @change=${(e: CustomEvent) => { {{variable_to_change}} = (e.target as any).value;} }
+  @input=${(e: CustomEvent) => { {{variable_to_change}} = (e.target as any).value;} }
   {{#if required}}
   required
   {{/if}}

--- a/templates/ui-frameworks/lit/field-types/String/TextField/edit/render.hbs
+++ b/templates/ui-frameworks/lit/field-types/String/TextField/edit/render.hbs
@@ -4,7 +4,7 @@
   {{#if variable_to_read}}
   .value=${ {{variable_to_read}}{{#if (not required)}} || ''{{/if}} }
   {{/if}}
-  @change=${(e: CustomEvent) => { {{variable_to_change}} = (e.target as any).value; } }
+  @input=${(e: CustomEvent) => { {{variable_to_change}} = (e.target as any).value; } }
   {{#if required}}
   required
   {{/if}}

--- a/templates/ui-frameworks/lit/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{kebab_case (plural from_referenceable.name)}}-for-{{kebab_case to_referenceable.name}}.ts{{¡if}}.hbs
+++ b/templates/ui-frameworks/lit/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{kebab_case (plural from_referenceable.name)}}-for-{{kebab_case to_referenceable.name}}.ts{{¡if}}.hbs
@@ -36,7 +36,7 @@ export class {{pascal_case (plural from_referenceable.name)}}For{{pascal_case to
       throw new Error(`The {{camel_case to_referenceable.singular_arg}} property is required for the {{kebab_case (plural from_referenceable.name)}}-for-{{kebab_case to_referenceable.name}} element`);
     }
 
-    this.client.on('signal', signal => {
+    this.client?.on('signal', signal => {
       if (!(SignalType.App in signal)) return;
       if (signal.App.zome_name !== '{{coordinator_zome_manifest.name}}') return;
       const payload = signal.App.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;

--- a/templates/ui-frameworks/lit/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and to_referenceable (ne to_referenceable.hash_type 'AgentPubKey'))}}{{kebab_case (plural to_referenceable.name)}}-for-{{kebab_case from_referenceable.name}}.ts{{¡if}}.hbs
+++ b/templates/ui-frameworks/lit/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and to_referenceable (ne to_referenceable.hash_type 'AgentPubKey'))}}{{kebab_case (plural to_referenceable.name)}}-for-{{kebab_case from_referenceable.name}}.ts{{¡if}}.hbs
@@ -36,7 +36,7 @@ export class {{pascal_case (plural to_referenceable.name)}}For{{pascal_case from
       throw new Error(`The {{camel_case from_referenceable.singular_arg}} property is required for the {{kebab_case (plural to_referenceable.name)}}-for-{{kebab_case from_referenceable.name}} element`);
     }
 
-    this.client.on('signal', signal => {
+    this.client?.on('signal', signal => {
       if (!(SignalType.App in signal)) return
       if (signal.App.zome_name !== '{{coordinator_zome_manifest.name}}') return;
       const payload = signal.App.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;

--- a/templates/ui-frameworks/lit/web-app/ui/package.json.hbs
+++ b/templates/ui-frameworks/lit/web-app/ui/package.json.hbs
@@ -50,6 +50,7 @@
       "prefer-destructuring": "off",
       "no-useless-constructor": "off",
       "no-empty-function": "off",
+      "no-nested-ternary": "off",
       "no-empty-pattern": "off",
       "no-console": "off",
       "no-alert": "off",


### PR DESCRIPTION
This PR:

- Replaces `@change` events with `@input` events in lit template inputs
- Fixes bug with the Enum field type on lit templates
- Use optional chaining when calling `this.client?.on` method