### PR TITLE
fix: preserve line comments on creating/ modifying rust code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3052,7 +3052,6 @@ dependencies = [
  "itertools 0.13.0",
  "markup_fmt",
  "mr_bundle",
- "once_cell",
  "path-clean",
  "pluralizer",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,3 @@ colored = "2.1.0"
 dprint-plugin-typescript = "0.91.1"
 markup_fmt = "0.10.0"
 git2 = { version = "0.19.0", default-features = false, features = ["https", "ssh_key_from_memory", "vendored-libgit2", "vendored-openssl"] }
-once_cell = "1.19.0"

--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -82,18 +82,7 @@ pub fn insert_file(
     let mut folder_path = file_path.to_path_buf();
     folder_path.pop();
 
-    let content = if folder_path.extension().unwrap_or_default().to_str() == Some("rs") {
-        // replace line comments wiht doc comments which are preserved on calling
-        // `prettyplease::unparse`
-        let re = Regex::new(r"^\/\/[^\/]|[^\/]\/\/[^\/]").unwrap();
-        let content = content.to_string();
-        &content
-            .lines()
-            .map(|line| re.replace_all(line, "/// ").into_owned() + "\n")
-            .collect::<String>()
-    } else {
-        content
-    };
+    let content = convert_rust_line_to_doc_comments(file_path, content);
 
     insert_file_tree_in_dir(
         file_tree,
@@ -205,8 +194,11 @@ pub fn map_rust_files<F: Fn(PathBuf, syn::File) -> ScaffoldResult<syn::File> + C
     map_all_files(file_tree, |file_path, contents| {
         if let Some(extension) = file_path.extension() {
             if extension == "rs" {
-                let original_file: syn::File = syn::parse_str(&contents)
-                    .map_err(|e| ScaffoldError::MalformedFile(file_path.clone(), e.to_string()))?;
+                let original_file: syn::File =
+                    syn::parse_str(&convert_rust_line_to_doc_comments(&file_path, &contents))
+                        .map_err(|e| {
+                            ScaffoldError::MalformedFile(file_path.clone(), e.to_string())
+                        })?;
                 let new_file = map_fn(file_path, original_file.clone())?;
                 // Only reformat the file via unparse_pretty if the contents of the newly modified
                 // file are different from the original
@@ -217,6 +209,37 @@ pub fn map_rust_files<F: Fn(PathBuf, syn::File) -> ScaffoldResult<syn::File> + C
         }
         Ok(contents)
     })
+}
+
+/// Converts line comments to doc comments in Rust files
+///
+/// This function is a workaround for a limitation in the `prettyplease::unparse` function,
+/// which is used to pretty-print Rust syntax trees. The `unparse` function discards line
+/// comments but preserves doc comments. To maintain all comments in the code, this function
+/// converts line comments to doc comments before parsing, allowing them to be preserved
+/// during the pretty-printing process.
+///
+/// After pretty-printing, these doc comments can be converted back to line comments if needed.
+///
+/// # Arguments
+///
+/// * `file_path` - A reference to the Path of the file being processed
+/// * `content` - A string slice containing the content of the file
+///
+/// # Returns
+///
+/// A String with line comments converted to doc comments if the file is a Rust file,
+/// otherwise returns the original content unchanged.
+fn convert_rust_line_to_doc_comments(file_path: &Path, content: &str) -> String {
+    if file_path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+        let re = Regex::new(r"^\/\/[^\/]|[^\/]\/\/[^\/]").expect("Failed to create regex");
+        content
+            .lines()
+            .map(|line| re.replace_all(line, "/// ").into_owned() + "\n")
+            .collect()
+    } else {
+        content.to_string()
+    }
 }
 
 pub fn flatten_file_tree(file_tree: &FileTree) -> BTreeMap<PathBuf, Option<String>> {

--- a/src/scaffold/dna/coordinator.rs
+++ b/src/scaffold/dna/coordinator.rs
@@ -9,29 +9,6 @@ use crate::{
 
 use super::{manifest::check_zome_doesnt_exist, zome_wasm_location, DnaFileTree};
 
-pub fn new_coordinator_zome_manifest(
-    dna_file_tree: &DnaFileTree,
-    name: &str,
-    maybe_dependencies: Option<&Vec<String>>,
-) -> ScaffoldResult<ZomeManifest> {
-    let location = zome_wasm_location(dna_file_tree, name);
-    let zome_manifest = ZomeManifest {
-        name: name.into(),
-        hash: None,
-        location,
-        dependencies: maybe_dependencies.map(|dz| {
-            dz.iter()
-                .map(|d| ZomeDependency {
-                    name: d.to_owned().into(),
-                })
-                .collect()
-        }),
-        dylib: None,
-    };
-
-    Ok(zome_manifest)
-}
-
 pub fn add_coordinator_zome_to_manifest(
     mut dna_file_tree: DnaFileTree,
     zome_manifest: ZomeManifest,
@@ -73,4 +50,27 @@ pub fn add_coordinator_zome_to_manifest(
     )?;
 
     Ok(dna_file_tree)
+}
+
+pub fn new_coordinator_zome_manifest(
+    dna_file_tree: &DnaFileTree,
+    name: &str,
+    maybe_dependencies: Option<&Vec<String>>,
+) -> ScaffoldResult<ZomeManifest> {
+    let location = zome_wasm_location(dna_file_tree, name);
+    let zome_manifest = ZomeManifest {
+        name: name.into(),
+        hash: None,
+        location,
+        dependencies: maybe_dependencies.map(|dz| {
+            dz.iter()
+                .map(|d| ZomeDependency {
+                    name: d.to_owned().into(),
+                })
+                .collect()
+        }),
+        dylib: None,
+    };
+
+    Ok(zome_manifest)
 }

--- a/src/scaffold/dna/integrity.rs
+++ b/src/scaffold/dna/integrity.rs
@@ -4,22 +4,6 @@ use crate::{error::ScaffoldResult, file_tree::insert_file};
 
 use super::{manifest::check_zome_doesnt_exist, zome_wasm_location, DnaFileTree};
 
-pub fn new_integrity_zome_manifest(
-    dna_file_tree: &DnaFileTree,
-    name: &str,
-) -> ScaffoldResult<ZomeManifest> {
-    let location = zome_wasm_location(dna_file_tree, name);
-    let zome_manifest = ZomeManifest {
-        name: name.into(),
-        hash: None,
-        location,
-        dependencies: None,
-        dylib: None,
-    };
-
-    Ok(zome_manifest)
-}
-
 pub fn add_integrity_zome_to_manifest(
     dna_file_tree: DnaFileTree,
     zome_manifest: ZomeManifest,
@@ -52,4 +36,20 @@ pub fn add_integrity_zome_to_manifest(
     let dna_file_tree = DnaFileTree::from_dna_manifest_path(file_tree, &dna_manifest_path)?;
 
     Ok(dna_file_tree)
+}
+
+pub fn new_integrity_zome_manifest(
+    dna_file_tree: &DnaFileTree,
+    name: &str,
+) -> ScaffoldResult<ZomeManifest> {
+    let location = zome_wasm_location(dna_file_tree, name);
+    let zome_manifest = ZomeManifest {
+        name: name.into(),
+        hash: None,
+        location,
+        dependencies: None,
+        dylib: None,
+    };
+
+    Ok(zome_manifest)
 }

--- a/src/scaffold/entry_type/coordinator.rs
+++ b/src/scaffold/entry_type/coordinator.rs
@@ -22,7 +22,129 @@ use super::{
     integrity::find_ending_match_expr_in_block,
 };
 
-pub fn no_update_read_handler(entry_def: &EntryDefinition) -> TokenStream {
+pub fn add_crud_functions_to_coordinator(
+    zome_file_tree: ZomeFileTree,
+    integrity_zome_name: &str,
+    entry_def: &EntryDefinition,
+    crud: &Crud,
+    link_from_original_to_each_update: bool,
+) -> ScaffoldResult<ZomeFileTree> {
+    let dna_manifest_path = zome_file_tree.dna_file_tree.dna_manifest_path.clone();
+    let zome_manifest = zome_file_tree.zome_manifest.clone();
+    let entry_def_snake_case_name = entry_def.snake_case_name();
+
+    // 1. Create an ENTRY_DEF_NAME.rs in "src/", with the appropriate crud functions
+    let crate_src_path = zome_file_tree.zome_crate_path.join("src");
+
+    let mut file_tree = zome_file_tree.dna_file_tree.file_tree();
+
+    let file = unparse_pretty(&initial_crud_handlers(
+        integrity_zome_name,
+        entry_def,
+        crud,
+        link_from_original_to_each_update,
+    ));
+
+    insert_file(
+        &mut file_tree,
+        &crate_src_path.join(format!("{}.rs", &entry_def_snake_case_name)),
+        &file,
+    )?;
+
+    // 2. Add this file as a module in the entry point for the crate
+    let lib_rs_path = crate_src_path.join("lib.rs");
+
+    map_file(&mut file_tree, &lib_rs_path, |contents| {
+        Ok(format!(
+            r#"pub mod {};
+{contents}"#,
+            &entry_def_snake_case_name
+        ))
+    })?;
+
+    let v = crate_src_path
+        .iter()
+        .map(|s| s.to_os_string())
+        .collect::<Vec<OsString>>();
+
+    map_rust_files(
+        file_tree
+            .path_mut(&mut v.iter())
+            .ok_or(ScaffoldError::PathNotFound(crate_src_path.clone()))?,
+        |file_path, mut file| {
+            if file_path == PathBuf::from("lib.rs") {
+                let mut first_entry_type_scaffolded = false;
+
+                for item in &mut file.items {
+                    if let syn::Item::Enum(item_enum) = item {
+                        if item_enum.ident == "Signal" && !signal_has_entry_types(item_enum) {
+                            first_entry_type_scaffolded = true;
+                            for v in signal_entry_types_variants()? {
+                                item_enum.variants.push(v);
+                            }
+                        }
+                    }
+
+                    if let syn::Item::Fn(item_fn) = item {
+                        if item_fn.sig.ident == "signal_action" {
+                            if find_ending_match_expr_in_block(&mut item_fn.block).is_none() {
+                                item_fn.block = Box::new(syn::parse_quote! {
+                                    {
+                                        match action.hashed.content.clone() {
+                                            _ => Ok(())
+                                        }
+                                    }
+                                });
+                            }
+
+                            if let Some(expr_match) =
+                                find_ending_match_expr_in_block(&mut item_fn.block)
+                            {
+                                if !signal_action_has_entry_types(expr_match) {
+                                    for arm in signal_action_match_arms()? {
+                                        expr_match.arms.insert(expr_match.arms.len() - 1, arm);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if first_entry_type_scaffolded {
+                    file.items.push(syn::parse_quote! {
+                        fn get_entry_for_action(action_hash: &ActionHash) -> ExternResult<Option<EntryTypes>> {
+                            let record = match get_details(action_hash.clone(), GetOptions::default())? {
+                                Some(Details::Record(record_details)) => record_details.record,
+                                _ => return Ok(None),
+                            };
+                            let entry = match record.entry().as_option() {
+                                Some(entry) => entry,
+                                None => return Ok(None),
+                            };
+                            let (zome_index, entry_index) = match record.action().entry_type() {
+                                Some(EntryType::App(AppEntryDef {
+                                    zome_index,
+                                    entry_index,
+                                    ..
+                                })) => (zome_index, entry_index),
+                                _ => return Ok(None),
+                            };
+                            EntryTypes::deserialize_from_type(*zome_index, *entry_index, entry)
+                        }
+                    });
+                }
+            }
+            Ok(file)
+        },
+    )?;
+
+    let dna_file_tree = DnaFileTree::from_dna_manifest_path(file_tree, &dna_manifest_path)?;
+    let zome_file_tree = ZomeFileTree::from_zome_manifest(dna_file_tree, zome_manifest)?;
+
+    Ok(zome_file_tree)
+}
+
+fn no_update_read_handler(entry_def: &EntryDefinition) -> TokenStream {
     let hash_type = entry_def.referenceable().hash_type().to_string();
     let snake_entry_def_name = entry_def.name.to_case(Case::Snake);
 
@@ -67,7 +189,7 @@ pub fn no_update_read_handler(entry_def: &EntryDefinition) -> TokenStream {
     }
 }
 
-pub fn read_handler_without_linking_to_updates(entry_def: &EntryDefinition) -> TokenStream {
+fn read_handler_without_linking_to_updates(entry_def: &EntryDefinition) -> TokenStream {
     let snake_entry_def_name = entry_def.name.clone();
     let original_hash_param_name = format_ident!("original_{snake_entry_def_name}_hash");
 
@@ -141,7 +263,7 @@ pub fn updates_link_name(entry_def_name: &str) -> String {
     format!("{}Updates", entry_def_name.to_case(Case::Pascal))
 }
 
-pub fn read_handler_with_linking_to_updates(entry_def: &EntryDefinition) -> TokenStream {
+fn read_handler_with_linking_to_updates(entry_def: &EntryDefinition) -> TokenStream {
     let snake_entry_def_name = entry_def.snake_case_name();
 
     let updates_link_name = format_ident!("{}", updates_link_name(&entry_def.name));
@@ -225,7 +347,7 @@ pub fn read_handler_with_linking_to_updates(entry_def: &EntryDefinition) -> Toke
     }
 }
 
-pub fn create_link_for_cardinality(
+fn create_link_for_cardinality(
     entry_def: &EntryDefinition,
     field_name: &str,
     link_type_name: &str,
@@ -264,7 +386,7 @@ pub fn create_link_for_cardinality(
     }
 }
 
-pub fn create_handler(entry_def: &EntryDefinition) -> TokenStream {
+fn create_handler(entry_def: &EntryDefinition) -> TokenStream {
     let pascal_entry_def_name = format_ident!("{}", entry_def.pascal_case_name());
     let snake_entry_def_name = format_ident!("{}", entry_def.snake_case_name());
 
@@ -315,7 +437,7 @@ pub fn create_handler(entry_def: &EntryDefinition) -> TokenStream {
     }
 }
 
-pub fn update_handler(
+fn update_handler(
     entry_def: &EntryDefinition,
     link_from_original_to_each_update: bool,
 ) -> TokenStream {
@@ -326,7 +448,7 @@ pub fn update_handler(
     }
 }
 
-pub fn update_handler_without_linking_on_each_update(entry_def: &EntryDefinition) -> TokenStream {
+fn update_handler_without_linking_on_each_update(entry_def: &EntryDefinition) -> TokenStream {
     let snake_entry_def_name = format_ident!("{}", entry_def.snake_case_name());
     let pascal_entry_def_name = format_ident!("{}", entry_def.pascal_case_name());
 
@@ -364,7 +486,7 @@ pub fn update_handler_without_linking_on_each_update(entry_def: &EntryDefinition
     }
 }
 
-pub fn update_handler_linking_on_each_update(entry_def: &EntryDefinition) -> TokenStream {
+fn update_handler_linking_on_each_update(entry_def: &EntryDefinition) -> TokenStream {
     let snake_entry_def_name = entry_def.snake_case_name();
     let pascal_entry_def_name = entry_def.pascal_case_name();
     let link_type_variant_name = updates_link_name(&entry_def.name);
@@ -413,7 +535,7 @@ pub fn update_handler_linking_on_each_update(entry_def: &EntryDefinition) -> Tok
     }
 }
 
-pub fn delete_handler(entry_def: &EntryDefinition) -> TokenStream {
+fn delete_handler(entry_def: &EntryDefinition) -> TokenStream {
     let pascal_entry_def_name = format_ident!("{}", entry_def.name.to_case(Case::Pascal));
     let snake_entry_def_name = format_ident!("{}", entry_def.name.to_case(Case::Snake));
 
@@ -673,126 +795,4 @@ fn signal_action_match_arms() -> ScaffoldResult<Vec<syn::Arm>> {
             }
         },
     ])
-}
-
-pub fn add_crud_functions_to_coordinator(
-    zome_file_tree: ZomeFileTree,
-    integrity_zome_name: &str,
-    entry_def: &EntryDefinition,
-    crud: &Crud,
-    link_from_original_to_each_update: bool,
-) -> ScaffoldResult<ZomeFileTree> {
-    let dna_manifest_path = zome_file_tree.dna_file_tree.dna_manifest_path.clone();
-    let zome_manifest = zome_file_tree.zome_manifest.clone();
-    let entry_def_snake_case_name = entry_def.snake_case_name();
-
-    // 1. Create an ENTRY_DEF_NAME.rs in "src/", with the appropriate crud functions
-    let crate_src_path = zome_file_tree.zome_crate_path.join("src");
-
-    let mut file_tree = zome_file_tree.dna_file_tree.file_tree();
-
-    let file = unparse_pretty(&initial_crud_handlers(
-        integrity_zome_name,
-        entry_def,
-        crud,
-        link_from_original_to_each_update,
-    ));
-
-    insert_file(
-        &mut file_tree,
-        &crate_src_path.join(format!("{}.rs", &entry_def_snake_case_name)),
-        &file,
-    )?;
-
-    // 2. Add this file as a module in the entry point for the crate
-    let lib_rs_path = crate_src_path.join("lib.rs");
-
-    map_file(&mut file_tree, &lib_rs_path, |contents| {
-        Ok(format!(
-            r#"pub mod {};
-{contents}"#,
-            &entry_def_snake_case_name
-        ))
-    })?;
-
-    let v = crate_src_path
-        .iter()
-        .map(|s| s.to_os_string())
-        .collect::<Vec<OsString>>();
-
-    map_rust_files(
-        file_tree
-            .path_mut(&mut v.iter())
-            .ok_or(ScaffoldError::PathNotFound(crate_src_path.clone()))?,
-        |file_path, mut file| {
-            if file_path == PathBuf::from("lib.rs") {
-                let mut first_entry_type_scaffolded = false;
-
-                for item in &mut file.items {
-                    if let syn::Item::Enum(item_enum) = item {
-                        if item_enum.ident == "Signal" && !signal_has_entry_types(item_enum) {
-                            first_entry_type_scaffolded = true;
-                            for v in signal_entry_types_variants()? {
-                                item_enum.variants.push(v);
-                            }
-                        }
-                    }
-
-                    if let syn::Item::Fn(item_fn) = item {
-                        if item_fn.sig.ident == "signal_action" {
-                            if find_ending_match_expr_in_block(&mut item_fn.block).is_none() {
-                                item_fn.block = Box::new(syn::parse_quote! {
-                                    {
-                                        match action.hashed.content.clone() {
-                                            _ => Ok(())
-                                        }
-                                    }
-                                });
-                            }
-
-                            if let Some(expr_match) =
-                                find_ending_match_expr_in_block(&mut item_fn.block)
-                            {
-                                if !signal_action_has_entry_types(expr_match) {
-                                    for arm in signal_action_match_arms()? {
-                                        expr_match.arms.insert(expr_match.arms.len() - 1, arm);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if first_entry_type_scaffolded {
-                    file.items.push(syn::parse_quote! {
-                        fn get_entry_for_action(action_hash: &ActionHash) -> ExternResult<Option<EntryTypes>> {
-                            let record = match get_details(action_hash.clone(), GetOptions::default())? {
-                                Some(Details::Record(record_details)) => record_details.record,
-                                _ => return Ok(None),
-                            };
-                            let entry = match record.entry().as_option() {
-                                Some(entry) => entry,
-                                None => return Ok(None),
-                            };
-                            let (zome_index, entry_index) = match record.action().entry_type() {
-                                Some(EntryType::App(AppEntryDef {
-                                    zome_index,
-                                    entry_index,
-                                    ..
-                                })) => (zome_index, entry_index),
-                                _ => return Ok(None),
-                            };
-                            EntryTypes::deserialize_from_type(*zome_index, *entry_index, entry)
-                        }
-                    });
-                }
-            }
-            Ok(file)
-        },
-    )?;
-
-    let dna_file_tree = DnaFileTree::from_dna_manifest_path(file_tree, &dna_manifest_path)?;
-    let zome_file_tree = ZomeFileTree::from_zome_manifest(dna_file_tree, zome_manifest)?;
-
-    Ok(zome_file_tree)
 }

--- a/src/scaffold/entry_type/definitions.rs
+++ b/src/scaffold/entry_type/definitions.rs
@@ -412,7 +412,7 @@ impl EntryDefinition {
         ts_interface.push('}');
         ts_enums
             .is_empty()
-            .then_some(ts_interface.clone())
+            .then(|| ts_interface.clone())
             .unwrap_or(format!("{ts_enums}\n{}", ts_interface.clone()))
     }
 }

--- a/src/scaffold/link_type/coordinator.rs
+++ b/src/scaffold/link_type/coordinator.rs
@@ -185,13 +185,15 @@ pub fn add_link_handler(
         format_ident!("{}", link_type_name(to_referenceable, from_referenceable));
 
     let bidirectional_create = bidirectional
-        .then_some(quote! {
-            create_link(
-                input.#target_field_name,
-                input.#base_field_name,
-                LinkTypes::#inverse_link_type_name,
-                (),
-            )?;
+        .then(|| {
+            quote! {
+                create_link(
+                    input.#target_field_name,
+                    input.#base_field_name,
+                    LinkTypes::#inverse_link_type_name,
+                    (),
+                )?;
+            }
         })
         .unwrap_or_default();
 
@@ -257,22 +259,24 @@ fn get_links_handler_to_agent(
     );
 
     let get_deleted_links_handler = delete
-        .then_some(quote::quote! {
-            #[hdk_extern]
-            pub fn #get_deleted_entry_for_entry_function_name(
-                #from_arg_name: #from_hash_type,
-            ) -> ExternResult<Vec<(SignedActionHashed, Vec<SignedActionHashed>)>> {
-                let details = get_link_details(
-                    #from_arg_name,
-                    LinkTypes::#pascal_link_type_name,
-                    None,
-                    GetOptions::default(),
-                )?;
-                Ok(details
-                    .into_inner()
-                    .into_iter()
-                    .filter(|(_link, deletes)| !deletes.is_empty())
-                    .collect())
+        .then(|| {
+            quote::quote! {
+                #[hdk_extern]
+                pub fn #get_deleted_entry_for_entry_function_name(
+                    #from_arg_name: #from_hash_type,
+                ) -> ExternResult<Vec<(SignedActionHashed, Vec<SignedActionHashed>)>> {
+                    let details = get_link_details(
+                        #from_arg_name,
+                        LinkTypes::#pascal_link_type_name,
+                        None,
+                        GetOptions::default(),
+                    )?;
+                    Ok(details
+                        .into_inner()
+                        .into_iter()
+                        .filter(|(_link, deletes)| !deletes.is_empty())
+                        .collect())
+                }
             }
         })
         .unwrap_or_default();
@@ -325,22 +329,24 @@ fn get_links_handler_to_entry(
     );
 
     let get_deleted_links_handler = delete
-        .then_some(quote::quote! {
-            #[hdk_extern]
-            pub fn #get_deleted_entry_for_entry_function_name(
-                #from_arg_name: #from_hash_type,
-            ) -> ExternResult<Vec<(SignedActionHashed, Vec<SignedActionHashed>)>> {
-                let details = get_link_details(
-                    #from_arg_name,
-                    LinkTypes::#pascal_link_type_name,
-                    None,
-                    GetOptions::default(),
-                )?;
-                Ok(details
-                    .into_inner()
-                    .into_iter()
-                    .filter(|(_link, deletes)| !deletes.is_empty())
-                    .collect())
+        .then(|| {
+            quote::quote! {
+                #[hdk_extern]
+                pub fn #get_deleted_entry_for_entry_function_name(
+                    #from_arg_name: #from_hash_type,
+                ) -> ExternResult<Vec<(SignedActionHashed, Vec<SignedActionHashed>)>> {
+                    let details = get_link_details(
+                        #from_arg_name,
+                        LinkTypes::#pascal_link_type_name,
+                        None,
+                        GetOptions::default(),
+                    )?;
+                    Ok(details
+                        .into_inner()
+                        .into_iter()
+                        .filter(|(_link, deletes)| !deletes.is_empty())
+                        .collect())
+                }
             }
         })
         .unwrap_or_default();
@@ -426,7 +432,7 @@ fn remove_link_handlers(
     let from_link = from_link_hash_type(&to_hash_type.to_string());
     let from_inverse = from_link_hash_type(&from_hash_type.to_string());
 
-    let bidirectional_remove = bidirectional.then_some(
+    let bidirectional_remove = bidirectional.then(||
         quote! {
             let links = get_links(
                 GetLinksInputBuilder::try_new(input.#target_field_name.clone(), LinkTypes::#inverse_link_type_name)?.build(),
@@ -470,19 +476,11 @@ fn normal_handlers(
     bidirectional: bool,
 ) -> TokenStream {
     let inverse_get = bidirectional
-        .then_some(get_links_handler(
-            to_referenceable,
-            from_referenceable,
-            delete,
-        ))
+        .then(|| get_links_handler(to_referenceable, from_referenceable, delete))
         .unwrap_or_default();
 
     let delete_link_handler = delete
-        .then_some(remove_link_handlers(
-            from_referenceable,
-            to_referenceable,
-            bidirectional,
-        ))
+        .then(|| remove_link_handlers(from_referenceable, to_referenceable, bidirectional))
         .unwrap_or_default();
 
     let integrity_zome_name = format_ident!("{integrity_zome_name}");

--- a/src/scaffold/zome.rs
+++ b/src/scaffold/zome.rs
@@ -14,7 +14,7 @@ use crate::{
         coordinator::scaffold_coordinator_zome_templates,
         integrity::scaffold_integrity_zome_templates, ScaffoldedTemplate,
     },
-    utils::input_with_case_and_initial_text,
+    utils::{input_with_case_and_initial_text, unparse_pretty},
     versions,
 };
 use build_fs_tree::{dir, file};
@@ -369,11 +369,15 @@ pub fn scaffold_integrity_zome_with_path(
     let mut file_tree =
         add_workspace_path_dependency(file_tree, zome_name, &path.join(&folder_name))?;
 
+    let initial_lib_rs = integrity::initial_lib_rs();
+
     // Add zome to workspace Cargo.toml
     let zome: FileTree = dir! {
         "Cargo.toml" => file!(integrity::initial_cargo_toml(zome_name)),
         "src" => dir! {
-            "lib.rs" => file!(integrity::initial_lib_rs())
+            "lib.rs" => file!(
+                unparse_pretty(&syn::parse_quote!{ #initial_lib_rs })
+            )
         }
     };
     insert_file_tree_in_dir(&mut file_tree, path, (OsString::from(folder_name), zome))?;
@@ -447,15 +451,17 @@ pub fn scaffold_coordinator_zome_in_path(
         add_coordinator_zome_to_manifest(dna_file_tree, coordinator_zome_manifest.clone())?;
 
     // Add zome to workspace Cargo.toml
-
     let file_tree = add_common_zome_dependencies_to_workspace_cargo(dna_file_tree.file_tree())?;
-
     let mut file_tree = add_workspace_path_dependency(file_tree, zome_name, &path.join(zome_name))?;
+
+    let initial_lib_rs = &coordinator::initial_lib_rs(dependencies);
 
     let zome: FileTree = dir! {
         "Cargo.toml" => file!(coordinator::initial_cargo_toml(zome_name, dependencies)),
         "src" => dir! {
-            "lib.rs" => file!(coordinator::initial_lib_rs(dependencies))
+            "lib.rs" => file!(
+                unparse_pretty(&syn::parse_quote!{ #initial_lib_rs })
+            )
         }
     };
 

--- a/src/scaffold/zome/coordinator.rs
+++ b/src/scaffold/zome/coordinator.rs
@@ -2,6 +2,8 @@ use std::{collections::BTreeMap, ffi::OsString};
 
 use dialoguer::{theme::ColorfulTheme, Select};
 use holochain_types::prelude::ZomeManifest;
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
 use syn::ItemFn;
 
 use crate::{
@@ -13,14 +15,14 @@ use crate::{
 use super::ZomeFileTree;
 
 pub fn initial_cargo_toml(zome_name: &str, dependencies: Option<&Vec<String>>) -> String {
-    let deps = match dependencies {
-        Some(d) => d
-            .iter()
-            .map(|d| format!(r#"{} = {{ workspace = true }}"#, d))
-            .collect::<Vec<String>>()
-            .join("\n"),
-        None => String::from(""),
-    };
+    let deps = dependencies
+        .map(|d| {
+            d.iter()
+                .map(|d| format!(r#"{} = {{ workspace = true }}"#, d))
+                .collect::<Vec<String>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
 
     format!(
         r#"[package]
@@ -40,51 +42,51 @@ serde = {{ workspace = true }}
     )
 }
 
-pub fn initial_lib_rs(dependencies: Option<&Vec<String>>) -> String {
-    let integrity_imports = match dependencies {
-        None => String::from(""),
-        Some(deps) => {
-            let mut s = String::from("");
-            for d in deps {
-                s.push_str(format!("use {d}::*;\n").as_str());
+pub fn initial_lib_rs(dependencies: Option<&Vec<String>>) -> TokenStream {
+    let integrity_imports = dependencies
+        .map(|deps| {
+            let imports = deps.iter().map(|d| {
+                let path =
+                    syn::parse_str::<syn::Path>(d).expect("Failed to parse dependency as path");
+                path.to_token_stream()
+            });
+            quote! {
+                #(use #imports::*;)*
             }
+        })
+        .unwrap_or_default();
 
-            s
+    quote! {
+        use hdk::prelude::*;
+        #integrity_imports
+
+        /// Called the first time a zome call is made to the cell containing this zome
+        #[hdk_extern]
+        pub fn init() -> ExternResult<InitCallbackResult> {
+            Ok(InitCallbackResult::Pass)
         }
-    };
-    format!(
-        r#"use hdk::prelude::*;
-{integrity_imports}
 
-// Called the first time a zome call is made to the cell containing this zome
-#[hdk_extern]
-pub fn init() -> ExternResult<InitCallbackResult> {{
-  Ok(InitCallbackResult::Pass)
-}}
+        /// Don't modify this enum if you want the scaffolding tool to generate appropriate signals for your entries and links
+        #[derive(Serialize, Deserialize, Debug)]
+        #[serde(tag = "type")]
+        pub enum Signal {}
 
-// Don't modify this enum if you want the scaffolding tool to generate appropriate signals for your entries and links
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(tag = "type")]
-pub enum Signal {{
-}}
+        /// Whenever an action is committed, we emit a signal to the UI elements to reactively update them
+        #[hdk_extern(infallible)]
+        pub fn post_commit(committed_actions: Vec<SignedActionHashed>) {
+            /// Don't modify this loop if you want the scaffolding tool to generate appropriate signals for your entries and links
+            for action in committed_actions {
+                if let Err(err) = signal_action(action) {
+                    error!("Error signaling new action: {:?}", err);
+                }
+            }
+        }
 
-// Whenever an action is committed, we emit a signal to the UI elements to reactively update them
-#[hdk_extern(infallible)]
-pub fn post_commit(committed_actions: Vec<SignedActionHashed>) {{
-    // Don't modify this loop if you want the scaffolding tool to generate appropriate signals for your entries and links
-    for action in committed_actions {{
-        if let Err(err) = signal_action(action) {{
-            error!("Error signaling new action: {{:?}}", err);
-        }}
-    }}
-}}
-
-// Don't modify this function if you want the scaffolding tool to generate appropriate signals for your entries and links
-fn signal_action(action: SignedActionHashed) -> ExternResult<()> {{
-    Ok(())
-}}
-"#
-    )
+        /// Don't modify this function if you want the scaffolding tool to generate appropriate signals for your entries and links
+        fn signal_action(action: SignedActionHashed) -> ExternResult<()> {
+            Ok(())
+        }
+    }
 }
 
 fn choose_extern_function(

--- a/src/scaffold/zome/coordinator.rs
+++ b/src/scaffold/zome/coordinator.rs
@@ -56,22 +56,22 @@ pub fn initial_lib_rs(dependencies: Option<&Vec<String>>) -> String {
         r#"use hdk::prelude::*;
 {integrity_imports}
 
-/// Called the first time a zome call is made to the cell containing this zome
+// Called the first time a zome call is made to the cell containing this zome
 #[hdk_extern]
 pub fn init() -> ExternResult<InitCallbackResult> {{
   Ok(InitCallbackResult::Pass)
 }}
 
-/// Don't modify this enum if you want the scaffolding tool to generate appropriate signals for your entries and links
+// Don't modify this enum if you want the scaffolding tool to generate appropriate signals for your entries and links
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "type")]
 pub enum Signal {{
 }}
 
-/// Whenever an action is committed, we emit a signal to the UI elements to reactively update them
+// Whenever an action is committed, we emit a signal to the UI elements to reactively update them
 #[hdk_extern(infallible)]
 pub fn post_commit(committed_actions: Vec<SignedActionHashed>) {{
-    /// Don't modify this loop if you want the scaffolding tool to generate appropriate signals for your entries and links
+    // Don't modify this loop if you want the scaffolding tool to generate appropriate signals for your entries and links
     for action in committed_actions {{
         if let Err(err) = signal_action(action) {{
             error!("Error signaling new action: {{:?}}", err);
@@ -79,7 +79,7 @@ pub fn post_commit(committed_actions: Vec<SignedActionHashed>) {{
     }}
 }}
 
-/// Don't modify this function if you want the scaffolding tool to generate appropriate signals for your entries and links
+// Don't modify this function if you want the scaffolding tool to generate appropriate signals for your entries and links
 fn signal_action(action: SignedActionHashed) -> ExternResult<()> {{
     Ok(())
 }}

--- a/src/scaffold/zome/integrity.rs
+++ b/src/scaffold/zome/integrity.rs
@@ -1,3 +1,6 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
 pub fn initial_cargo_toml(zome_name: &str) -> String {
     format!(
         r#"[package]
@@ -16,158 +19,159 @@ serde = {{ workspace = true }}
     )
 }
 
-pub fn initial_lib_rs() -> String {
-    r#"use hdi::prelude::*;
+pub fn initial_lib_rs() -> TokenStream {
+    quote! {
+        use hdi::prelude::*;
 
-// Validation you perform during the genesis process. Nobody else on the network performs it, only you.
-// There *is no* access to network calls in this callback
-#[hdk_extern]
-pub fn genesis_self_check(_data: GenesisSelfCheckData) -> ExternResult<ValidateCallbackResult> {
-    Ok(ValidateCallbackResult::Valid)
-}
+        /// Validation you perform during the genesis process. Nobody else on the network performs it, only you.
+        /// There *is no* access to network calls in this callback
+        #[hdk_extern]
+        pub fn genesis_self_check(_data: GenesisSelfCheckData) -> ExternResult<ValidateCallbackResult> {
+            Ok(ValidateCallbackResult::Valid)
+        }
 
-// Validation the network performs when you try to join, you can't perform this validation yourself as you are not a member yet.
-// There *is* access to network calls in this function
-pub fn validate_agent_joining(_agent_pub_key: AgentPubKey, _membrane_proof: &Option<MembraneProof>) -> ExternResult<ValidateCallbackResult> {
-    Ok(ValidateCallbackResult::Valid)
-}
+        /// Validation the network performs when you try to join, you can't perform this validation yourself as you are not a member yet.
+        /// There *is* access to network calls in this function
+        pub fn validate_agent_joining(_agent_pub_key: AgentPubKey, _membrane_proof: &Option<MembraneProof>) -> ExternResult<ValidateCallbackResult> {
+            Ok(ValidateCallbackResult::Valid)
+        }
 
-// This is the unified validation callback for all entries and link types in this integrity zome
-// Below is a match template for all of the variants of `DHT Ops` and entry and link types
-//
-// Holochain has already performed the following validation for you:
-// - The action signature matches on the hash of its content and is signed by its author
-// - The previous action exists, has a lower timestamp than the new action, and incremented sequence number
-// - The previous action author is the same as the new action author
-// - The timestamp of each action is after the DNA's origin time
-// - AgentActivity authorities check that the agent hasn't forked their chain
-// - The entry hash in the action matches the entry content
-// - The entry type in the action matches the entry content
-// - The entry size doesn't exceed the maximum entry size (currently 4MB)
-// - Private entry types are not included in the Op content, and public entry types are
-// - If the `Op` is an update or a delete, the original action exists and is a `Create` or `Update` action
-// - If the `Op` is an update, the original entry exists and is of the same type as the new one
-// - If the `Op` is a delete link, the original action exists and is a `CreateLink` action
-// - Link tags don't exceed the maximum tag size (currently 1KB)
-// - Countersigned entries include an action from each required signer
-//
-// You can read more about validation here: https://docs.rs/hdi/latest/hdi/index.html#data-validation
-#[hdk_extern]
-pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
-    match op.flattened::<(), ()>()? {
-        FlatOp::StoreEntry(store_entry) => match store_entry {
-            OpEntry::CreateEntry {
-                app_entry,
-                action,
-            } => Ok(ValidateCallbackResult::Invalid(
-                "There are no entry types in this integrity zome".to_string(),
-            )),
-            OpEntry::UpdateEntry {
-                app_entry,
-                action,
-                ..
-            } => Ok(ValidateCallbackResult::Invalid(
-                "There are no entry types in this integrity zome".to_string(),
-            )),
-            _ => Ok(ValidateCallbackResult::Valid)
-        },
-        FlatOp::RegisterUpdate(update_entry) => match update_entry {
-            OpUpdate::Entry { app_entry, action } => {
-                Ok(ValidateCallbackResult::Invalid(
+        /// This is the unified validation callback for all entries and link types in this integrity zome
+        /// Below is a match template for all of the variants of `DHT Ops` and entry and link types
+        ///
+        /// Holochain has already performed the following validation for you:
+        /// - The action signature matches on the hash of its content and is signed by its author
+        /// - The previous action exists, has a lower timestamp than the new action, and incremented sequence number
+        /// - The previous action author is the same as the new action author
+        /// - The timestamp of each action is after the DNA's origin time
+        /// - AgentActivity authorities check that the agent hasn't forked their chain
+        /// - The entry hash in the action matches the entry content
+        /// - The entry type in the action matches the entry content
+        /// - The entry size doesn't exceed the maximum entry size (currently 4MB)
+        /// - Private entry types are not included in the Op content, and public entry types are
+        /// - If the `Op` is an update or a delete, the original action exists and is a `Create` or `Update` action
+        /// - If the `Op` is an update, the original entry exists and is of the same type as the new one
+        /// - If the `Op` is a delete link, the original action exists and is a `CreateLink` action
+        /// - Link tags don't exceed the maximum tag size (currently 1KB)
+        /// - Countersigned entries include an action from each required signer
+        ///
+        /// You can read more about validation here: https://docs.rs/hdi/latest/hdi/index.html#data-validation
+        #[hdk_extern]
+        pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+            match op.flattened::<(), ()>()? {
+                FlatOp::StoreEntry(store_entry) => match store_entry {
+                    OpEntry::CreateEntry {
+                        app_entry,
+                        action,
+                    } => Ok(ValidateCallbackResult::Invalid(
+                        "There are no entry types in this integrity zome".to_string(),
+                    )),
+                    OpEntry::UpdateEntry {
+                        app_entry,
+                        action,
+                        ..
+                    } => Ok(ValidateCallbackResult::Invalid(
+                        "There are no entry types in this integrity zome".to_string(),
+                    )),
+                    _ => Ok(ValidateCallbackResult::Valid)
+                },
+                FlatOp::RegisterUpdate(update_entry) => match update_entry {
+                    OpUpdate::Entry { app_entry, action } => {
+                        Ok(ValidateCallbackResult::Invalid(
+                            "There are no entry types in this integrity zome".to_string(),
+                        ))
+                    },
+                    _ => Ok(ValidateCallbackResult::Valid)
+                },
+                FlatOp::RegisterDelete(delete_entry) => Ok(ValidateCallbackResult::Invalid(
                     "There are no entry types in this integrity zome".to_string(),
-                ))
-            },
-            _ => Ok(ValidateCallbackResult::Valid)
-        },
-        FlatOp::RegisterDelete(delete_entry) => Ok(ValidateCallbackResult::Invalid(
-            "There are no entry types in this integrity zome".to_string(),
-        )),
-        FlatOp::RegisterCreateLink {
-            link_type,
-            base_address,
-            target_address,
-            tag,
-            action
-        } => Ok(ValidateCallbackResult::Invalid(
-            "There are no link types in this integrity zome".to_string()
-        )),
-        FlatOp::RegisterDeleteLink {
-            link_type,
-            base_address,
-            target_address,
-            tag,
-            original_action,
-            action
-        } => Ok(ValidateCallbackResult::Invalid("There are no link types in this integrity zome".to_string())),
-        FlatOp::StoreRecord(store_record) => match store_record {
-            // Complementary validation to the `StoreEntry` Op, in which the record itself is validated
-            // If you want to optimize performance, you can remove the validation for an entry type here and keep it in `StoreEntry`
-            // Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `StoreEntry` validation failed
-            OpRecord::CreateEntry {
-                app_entry,
-                action
-            } => Ok(ValidateCallbackResult::Invalid("There are no entry types in this integrity zome".to_string())),
-            // Complementary validation to the `RegisterUpdate` Op, in which the record itself is validated
-            // If you want to optimize performance, you can remove the validation for an entry type here and keep it in `StoreEntry` and in `RegisterUpdate`
-            // Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the other validations failed
-            OpRecord::UpdateEntry {
-                original_action_hash,
-                app_entry,
-                action,
-                ..
-            } => Ok(ValidateCallbackResult::Invalid("There are no entry types in this integrity zome".to_string())),
-            // Complementary validation to the `RegisterDelete` Op, in which the record itself is validated
-            // If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterDelete`
-            // Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterDelete` validation failed
-            OpRecord::DeleteEntry {
-                original_action_hash,
-                action,
-                ..
-            } => Ok(ValidateCallbackResult::Invalid("There are no entry types in this integrity zome".to_string())),
-            // Complementary validation to the `RegisterCreateLink` Op, in which the record itself is validated
-            // If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterCreateLink`
-            // Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterCreateLink` validation failed
-            OpRecord::CreateLink {
-                base_address,
-                target_address,
-                tag,
-                link_type,
-                action
-            } => Ok(ValidateCallbackResult::Invalid("There are no link types in this integrity zome".to_string())),
-            // Complementary validation to the `RegisterDeleteLink` Op, in which the record itself is validated
-            // If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterDeleteLink`
-            // Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterDeleteLink` validation failed
-            OpRecord::DeleteLink {
-                original_action_hash,
-                base_address,
-                action
-            } => Ok(ValidateCallbackResult::Invalid("There are no link types in this integrity zome".to_string())),
-            OpRecord::CreatePrivateEntry { .. } => Ok(ValidateCallbackResult::Valid),
-            OpRecord::UpdatePrivateEntry { .. } => Ok(ValidateCallbackResult::Valid),
-            OpRecord::CreateCapClaim { .. } => Ok(ValidateCallbackResult::Valid),
-            OpRecord::CreateCapGrant { .. } => Ok(ValidateCallbackResult::Valid),
-            OpRecord::UpdateCapClaim { .. } => Ok(ValidateCallbackResult::Valid),
-            OpRecord::UpdateCapGrant { .. } => Ok(ValidateCallbackResult::Valid),
-            OpRecord::Dna { .. } => Ok(ValidateCallbackResult::Valid),
-            OpRecord::OpenChain { .. } => Ok(ValidateCallbackResult::Valid),
-            OpRecord::CloseChain { .. } => Ok(ValidateCallbackResult::Valid),
-            OpRecord::InitZomesComplete { .. } => Ok(ValidateCallbackResult::Valid),
-            _ => Ok(ValidateCallbackResult::Valid)
-        },
-        FlatOp::RegisterAgentActivity(agent_activity) => match agent_activity {
-            OpActivity::CreateAgent {
-                agent,
-                action
-            } => {
-                let previous_action = must_get_action(action.prev_action)?;
-                match previous_action.action() {
-                    Action::AgentValidationPkg(AgentValidationPkg { membrane_proof, .. }) => validate_agent_joining(agent, membrane_proof),
-                    _ => Ok(ValidateCallbackResult::Invalid("The previous action for a `CreateAgent` action must be an `AgentValidationPkg`".to_string()))
-                }
-            },
-            _ => Ok(ValidateCallbackResult::Valid)
-        },
+                )),
+                FlatOp::RegisterCreateLink {
+                    link_type,
+                    base_address,
+                    target_address,
+                    tag,
+                    action
+                } => Ok(ValidateCallbackResult::Invalid(
+                    "There are no link types in this integrity zome".to_string()
+                )),
+                FlatOp::RegisterDeleteLink {
+                    link_type,
+                    base_address,
+                    target_address,
+                    tag,
+                    original_action,
+                    action
+                } => Ok(ValidateCallbackResult::Invalid("There are no link types in this integrity zome".to_string())),
+                FlatOp::StoreRecord(store_record) => match store_record {
+                    /// Complementary validation to the `StoreEntry` Op, in which the record itself is validated
+                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `StoreEntry`
+                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `StoreEntry` validation failed
+                    OpRecord::CreateEntry {
+                        app_entry,
+                        action
+                    } => Ok(ValidateCallbackResult::Invalid("There are no entry types in this integrity zome".to_string())),
+                    /// Complementary validation to the `RegisterUpdate` Op, in which the record itself is validated
+                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `StoreEntry` and in `RegisterUpdate`
+                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the other validations failed
+                    OpRecord::UpdateEntry {
+                        original_action_hash,
+                        app_entry,
+                        action,
+                        ..
+                    } => Ok(ValidateCallbackResult::Invalid("There are no entry types in this integrity zome".to_string())),
+                    /// Complementary validation to the `RegisterDelete` Op, in which the record itself is validated
+                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterDelete`
+                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterDelete` validation failed
+                    OpRecord::DeleteEntry {
+                        original_action_hash,
+                        action,
+                        ..
+                    } => Ok(ValidateCallbackResult::Invalid("There are no entry types in this integrity zome".to_string())),
+                    /// Complementary validation to the `RegisterCreateLink` Op, in which the record itself is validated
+                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterCreateLink`
+                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterCreateLink` validation failed
+                    OpRecord::CreateLink {
+                        base_address,
+                        target_address,
+                        tag,
+                        link_type,
+                        action
+                    } => Ok(ValidateCallbackResult::Invalid("There are no link types in this integrity zome".to_string())),
+                    /// Complementary validation to the `RegisterDeleteLink` Op, in which the record itself is validated
+                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterDeleteLink`
+                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterDeleteLink` validation failed
+                    OpRecord::DeleteLink {
+                        original_action_hash,
+                        base_address,
+                        action
+                    } => Ok(ValidateCallbackResult::Invalid("There are no link types in this integrity zome".to_string())),
+                    OpRecord::CreatePrivateEntry { .. } => Ok(ValidateCallbackResult::Valid),
+                    OpRecord::UpdatePrivateEntry { .. } => Ok(ValidateCallbackResult::Valid),
+                    OpRecord::CreateCapClaim { .. } => Ok(ValidateCallbackResult::Valid),
+                    OpRecord::CreateCapGrant { .. } => Ok(ValidateCallbackResult::Valid),
+                    OpRecord::UpdateCapClaim { .. } => Ok(ValidateCallbackResult::Valid),
+                    OpRecord::UpdateCapGrant { .. } => Ok(ValidateCallbackResult::Valid),
+                    OpRecord::Dna { .. } => Ok(ValidateCallbackResult::Valid),
+                    OpRecord::OpenChain { .. } => Ok(ValidateCallbackResult::Valid),
+                    OpRecord::CloseChain { .. } => Ok(ValidateCallbackResult::Valid),
+                    OpRecord::InitZomesComplete { .. } => Ok(ValidateCallbackResult::Valid),
+                    _ => Ok(ValidateCallbackResult::Valid)
+                },
+                FlatOp::RegisterAgentActivity(agent_activity) => match agent_activity {
+                    OpActivity::CreateAgent {
+                        agent,
+                        action
+                    } => {
+                        let previous_action = must_get_action(action.prev_action)?;
+                        match previous_action.action() {
+                            Action::AgentValidationPkg(AgentValidationPkg { membrane_proof, .. }) => validate_agent_joining(agent, membrane_proof),
+                            _ => Ok(ValidateCallbackResult::Invalid("The previous action for a `CreateAgent` action must be an `AgentValidationPkg`".to_string()))
+                        }
+                    },
+                    _ => Ok(ValidateCallbackResult::Valid)
+                },
+            }
+        }
     }
-}
-"#.to_string()
 }

--- a/src/scaffold/zome/integrity.rs
+++ b/src/scaffold/zome/integrity.rs
@@ -19,39 +19,39 @@ serde = {{ workspace = true }}
 pub fn initial_lib_rs() -> String {
     r#"use hdi::prelude::*;
 
-/// Validation you perform during the genesis process. Nobody else on the network performs it, only you.
-/// There *is no* access to network calls in this callback
+// Validation you perform during the genesis process. Nobody else on the network performs it, only you.
+// There *is no* access to network calls in this callback
 #[hdk_extern]
 pub fn genesis_self_check(_data: GenesisSelfCheckData) -> ExternResult<ValidateCallbackResult> {
     Ok(ValidateCallbackResult::Valid)
 }
 
-/// Validation the network performs when you try to join, you can't perform this validation yourself as you are not a member yet.
-/// There *is* access to network calls in this function
+// Validation the network performs when you try to join, you can't perform this validation yourself as you are not a member yet.
+// There *is* access to network calls in this function
 pub fn validate_agent_joining(_agent_pub_key: AgentPubKey, _membrane_proof: &Option<MembraneProof>) -> ExternResult<ValidateCallbackResult> {
     Ok(ValidateCallbackResult::Valid)
 }
 
-/// This is the unified validation callback for all entries and link types in this integrity zome
-/// Below is a match template for all of the variants of `DHT Ops` and entry and link types
-///
-/// Holochain has already performed the following validation for you:
-/// - The action signature matches on the hash of its content and is signed by its author
-/// - The previous action exists, has a lower timestamp than the new action, and incremented sequence number
-/// - The previous action author is the same as the new action author
-/// - The timestamp of each action is after the DNA's origin time
-/// - AgentActivity authorities check that the agent hasn't forked their chain
-/// - The entry hash in the action matches the entry content
-/// - The entry type in the action matches the entry content
-/// - The entry size doesn't exceed the maximum entry size (currently 4MB)
-/// - Private entry types are not included in the Op content, and public entry types are
-/// - If the `Op` is an update or a delete, the original action exists and is a `Create` or `Update` action
-/// - If the `Op` is an update, the original entry exists and is of the same type as the new one
-/// - If the `Op` is a delete link, the original action exists and is a `CreateLink` action
-/// - Link tags don't exceed the maximum tag size (currently 1KB)
-/// - Countersigned entries include an action from each required signer 
-///
-/// You can read more about validation here: https://docs.rs/hdi/latest/hdi/index.html#data-validation
+// This is the unified validation callback for all entries and link types in this integrity zome
+// Below is a match template for all of the variants of `DHT Ops` and entry and link types
+//
+// Holochain has already performed the following validation for you:
+// - The action signature matches on the hash of its content and is signed by its author
+// - The previous action exists, has a lower timestamp than the new action, and incremented sequence number
+// - The previous action author is the same as the new action author
+// - The timestamp of each action is after the DNA's origin time
+// - AgentActivity authorities check that the agent hasn't forked their chain
+// - The entry hash in the action matches the entry content
+// - The entry type in the action matches the entry content
+// - The entry size doesn't exceed the maximum entry size (currently 4MB)
+// - Private entry types are not included in the Op content, and public entry types are
+// - If the `Op` is an update or a delete, the original action exists and is a `Create` or `Update` action
+// - If the `Op` is an update, the original entry exists and is of the same type as the new one
+// - If the `Op` is a delete link, the original action exists and is a `CreateLink` action
+// - Link tags don't exceed the maximum tag size (currently 1KB)
+// - Countersigned entries include an action from each required signer
+//
+// You can read more about validation here: https://docs.rs/hdi/latest/hdi/index.html#data-validation
 #[hdk_extern]
 pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
     match op.flattened::<(), ()>()? {
@@ -100,33 +100,33 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             action
         } => Ok(ValidateCallbackResult::Invalid("There are no link types in this integrity zome".to_string())),
         FlatOp::StoreRecord(store_record) => match store_record {
-            /// Complementary validation to the `StoreEntry` Op, in which the record itself is validated
-            /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `StoreEntry`
-            /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `StoreEntry` validation failed
+            // Complementary validation to the `StoreEntry` Op, in which the record itself is validated
+            // If you want to optimize performance, you can remove the validation for an entry type here and keep it in `StoreEntry`
+            // Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `StoreEntry` validation failed
             OpRecord::CreateEntry {
                 app_entry,
                 action
             } => Ok(ValidateCallbackResult::Invalid("There are no entry types in this integrity zome".to_string())),
-            /// Complementary validation to the `RegisterUpdate` Op, in which the record itself is validated
-            /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `StoreEntry` and in `RegisterUpdate`
-            /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the other validations failed
+            // Complementary validation to the `RegisterUpdate` Op, in which the record itself is validated
+            // If you want to optimize performance, you can remove the validation for an entry type here and keep it in `StoreEntry` and in `RegisterUpdate`
+            // Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the other validations failed
             OpRecord::UpdateEntry {
                 original_action_hash,
                 app_entry,
                 action,
                 ..
             } => Ok(ValidateCallbackResult::Invalid("There are no entry types in this integrity zome".to_string())),
-            /// Complementary validation to the `RegisterDelete` Op, in which the record itself is validated
-            /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterDelete`
-            /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterDelete` validation failed
+            // Complementary validation to the `RegisterDelete` Op, in which the record itself is validated
+            // If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterDelete`
+            // Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterDelete` validation failed
             OpRecord::DeleteEntry {
                 original_action_hash,
                 action,
                 ..
             } => Ok(ValidateCallbackResult::Invalid("There are no entry types in this integrity zome".to_string())),
-            /// Complementary validation to the `RegisterCreateLink` Op, in which the record itself is validated
-            /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterCreateLink`
-            /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterCreateLink` validation failed
+            // Complementary validation to the `RegisterCreateLink` Op, in which the record itself is validated
+            // If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterCreateLink`
+            // Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterCreateLink` validation failed
             OpRecord::CreateLink {
                 base_address,
                 target_address,
@@ -134,9 +134,9 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                 link_type,
                 action
             } => Ok(ValidateCallbackResult::Invalid("There are no link types in this integrity zome".to_string())),
-            /// Complementary validation to the `RegisterDeleteLink` Op, in which the record itself is validated
-            /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterDeleteLink`
-            /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterDeleteLink` validation failed
+            // Complementary validation to the `RegisterDeleteLink` Op, in which the record itself is validated
+            // If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterDeleteLink`
+            // Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterDeleteLink` validation failed
             OpRecord::DeleteLink {
                 original_action_hash,
                 base_address,

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,11 +1,11 @@
 use anyhow::Context;
 use build_fs_tree::serde::Serialize;
 use handlebars::Handlebars;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 use crate::error::{ScaffoldError, ScaffoldResult};
 use crate::file_tree::{
@@ -24,15 +24,15 @@ pub mod integrity;
 pub mod link_type;
 pub mod web_app;
 
-static EACH_TEMPLATE_REGEX: Lazy<Regex> = Lazy::new(|| {
+static EACH_TEMPLATE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?P<c>(.)*)/\{\{#each (?P<b>([^\{\}])*)\}\}(?P<a>(.)*)\{\{/each\}\}.hbs\z")
         .expect("EACH_TEMPLATE_REGEX is invalid")
 });
-static EACH_IF_TEMPLATE_REGEX: Lazy<Regex> = Lazy::new(|| {
+static EACH_IF_TEMPLATE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?P<c>(.)*)/\{\{#each (?P<b>([^\{\}])*)\}\}\{\{#if (?P<d>([^\{\}])*)\}\}(?P<a>(.)*)\{\{/if\}\}\{\{/each\}\}.hbs\z")
         .expect("EACH_IF_TEMPLATE_REGEX is invalid")
 });
-static IF_TEMPLATE_REGEX: Lazy<Regex> = Lazy::new(|| {
+static IF_TEMPLATE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?P<c>(.)*)/\{\{#if (?P<b>([^\{\}])*)\}\}(?P<a>(.)*)\{\{/if\}\}.hbs\z")
         .expect("IF_TEMPLATE_REGEX is invalid")
 });

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,6 @@ use anyhow::Context;
 use convert_case::{Case, Casing};
 use dialoguer::{theme::ColorfulTheme, Input, Select, Validator};
 use dprint_plugin_typescript::configuration::ConfigurationBuilder;
-use regex::Regex;
 
 use crate::error::{ScaffoldError, ScaffoldResult};
 use crate::file_tree::{dir_content, FileTree};
@@ -178,49 +177,104 @@ pub fn check_no_whitespace(input: &str, identifier: &str) -> ScaffoldResult<()> 
     Ok(())
 }
 
-#[inline]
-/// Unparses a parsed `syn::File` to formatted rust code
-/// as a String. Formatting is handled under the hood by `prettyplease::unparse`
-pub fn unparse_pretty(file: &syn::File) -> String {
-    add_newlines(&prettyplease::unparse(file).replace("///", "//"))
-}
-
 /// Inserts new lines that are stripped out by `syn` during programmatic
 /// manipulation of Rust code. Newlines and white spaces are not considered
 /// tokens by `syn`, so this function restores them to improve code readability.
-fn add_newlines(input: &str) -> String {
-    let mut formatted_code = String::new();
-    let lines: Vec<&str> = input.lines().collect();
-    let mut after_imports = false;
+#[inline]
+pub fn unparse_pretty(code: &syn::File) -> String {
+    let formatted = prettyplease::unparse(code);
+    let lines = formatted.lines().collect::<Vec<&str>>();
+
+    let mut result = String::new();
+
+    let mut last_line_was_import = false;
+    let mut in_attribute = false;
+    let mut in_struct = false;
+    let mut in_function = false;
+    let mut brace_count = 0;
+
+    // Iterate through the lines, adding extra newlines where needed
     for (i, line) in lines.iter().enumerate() {
-        // Add a newline after the imports block
-        if !after_imports && line.trim().is_empty() {
-            after_imports = true;
-            formatted_code.push('\n');
+        let trimmed_line = line.trim();
+
+        // Check if this line is an import
+        let is_import = trimmed_line.starts_with("use ");
+        let next_line_is_comment = lines.get(i + 1).unwrap_or(&"").starts_with("//");
+        let is_comment = trimmed_line.starts_with("//");
+
+        // Check if we're entering or exiting an attribute
+        if trimmed_line.starts_with("#[") {
+            in_attribute = true;
+        } else if in_attribute && !trimmed_line.ends_with(']') {
+            in_attribute = false;
         }
 
-        // Add newlines between #[hdk_extern] annotated functions
-        if line.trim().starts_with("#[hdk_extern") && i > 0 {
-            formatted_code.push('\n');
+        // Check if we're entering or exiting a struct or function
+        if trimmed_line.starts_with("pub struct ") || trimmed_line.starts_with("struct ") {
+            in_struct = true;
+        } else if trimmed_line.starts_with("pub fn ") || trimmed_line.starts_with("fn ") {
+            in_function = true;
         }
 
-        // Add newlines between non #[hdk_extern] annoteted functions
-        let functon_regex =
-            Regex::new(r"(?m)^\s*(pub\s+fn|fn)\s+\w+\s*\(").expect("functon_regex is invalid");
-        if (functon_regex.is_match(line.trim()) && i > 0)
-            && (!lines[i - 1].starts_with("#[hdk_extern"))
+        // Count braces to determine when we exit a struct or function
+        brace_count += trimmed_line.chars().filter(|&c| c == '{').count() as i32;
+        brace_count -= trimmed_line.chars().filter(|&c| c == '}').count() as i32;
+
+        if brace_count == 0 {
+            in_struct = false;
+            in_function = false;
+        }
+
+        // Add an extra newline after the imports section
+        if last_line_was_import && !is_import && !in_attribute {
+            result.push('\n');
+        }
+
+        // Add the current line
+        result.push_str(line);
+        result.push('\n');
+
+        // Add an extra newline between major items, but not after attributes or within structs/functions
+        if !in_attribute
+            && !in_struct
+            && !in_function
+            && !is_comment
+            && i + 1 < lines.len()
+            && should_add_newline(trimmed_line, lines[i + 1].trim())
         {
-            formatted_code.push('\n');
+            result.push('\n');
         }
 
-        // Add newlines between #[derive] annotated structs/enums
-        if line.trim().starts_with("#[derive") && i > 0 {
-            formatted_code.push('\n');
+        // Add an extra newline after before comment
+        if next_line_is_comment {
+            result.push('\n');
         }
-        formatted_code.push_str(line);
-        formatted_code.push('\n');
+
+        last_line_was_import = is_import;
     }
-    formatted_code
+
+    // Final cleanup: remove any triple (or more) newlines
+    while result.contains("\n\n\n") {
+        result = result.replace("\n\n\n", "\n\n");
+    }
+
+    result
+}
+
+fn should_add_newline(current: &str, next: &str) -> bool {
+    let major_items = [
+        "pub struct ",
+        "struct ",
+        "pub enum ",
+        "enum ",
+        "pub fn ",
+        "fn ",
+        "#[",
+    ];
+
+    major_items
+        .iter()
+        .any(|&item| current.starts_with(item) || next.starts_with(item))
 }
 
 /// Tries to progrmatically format generated ui code if the file extension matches

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -180,7 +180,6 @@ pub fn check_no_whitespace(input: &str, identifier: &str) -> ScaffoldResult<()> 
 /// Inserts new lines that are stripped out by `syn` during programmatic
 /// manipulation of Rust code. Newlines and white spaces are not considered
 /// tokens by `syn`, so this function restores them to improve code readability.
-#[inline]
 pub fn unparse_pretty(code: &syn::File) -> String {
     // replace previously converted line comment to doc comments back to line comments
     let formatted = prettyplease::unparse(code).replace("///", "//");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -188,6 +188,7 @@ pub fn unparse_pretty(code: &syn::File) -> String {
     let mut result = String::new();
 
     let mut last_line_was_import = false;
+    let mut last_line_was_comment = false;
     let mut in_attribute = false;
     let mut in_struct = false;
     let mut in_function = false;
@@ -245,11 +246,12 @@ pub fn unparse_pretty(code: &syn::File) -> String {
             result.push('\n');
         }
 
-        if next_line_is_comment {
+        if next_line_is_comment && !last_line_was_comment && !is_comment {
             result.push('\n');
         }
 
         last_line_was_import = is_import;
+        last_line_was_comment = is_comment;
     }
 
     // Final cleanup: remove any triple (or more) newlines

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -182,9 +182,8 @@ pub fn check_no_whitespace(input: &str, identifier: &str) -> ScaffoldResult<()> 
 /// tokens by `syn`, so this function restores them to improve code readability.
 #[inline]
 pub fn unparse_pretty(code: &syn::File) -> String {
-    let formatted = prettyplease::unparse(code);
+    let formatted = prettyplease::unparse(code).replace("///", "//");
     let lines = formatted.lines().collect::<Vec<&str>>();
-
     let mut result = String::new();
 
     let mut last_line_was_import = false;
@@ -245,7 +244,6 @@ pub fn unparse_pretty(code: &syn::File) -> String {
             result.push('\n');
         }
 
-        // Add an extra newline after before comment
         if next_line_is_comment {
             result.push('\n');
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -182,6 +182,7 @@ pub fn check_no_whitespace(input: &str, identifier: &str) -> ScaffoldResult<()> 
 /// tokens by `syn`, so this function restores them to improve code readability.
 #[inline]
 pub fn unparse_pretty(code: &syn::File) -> String {
+    // replace previously converted line comment to doc comments back to line comments
     let formatted = prettyplease::unparse(code).replace("///", "//");
     let lines = formatted.lines().collect::<Vec<&str>>();
     let mut result = String::new();


### PR DESCRIPTION
This PR ensures line comments are preserved on modifying or creating new rust files while running scaffold commands that do so.

While this PR addresses the problem, it does open up another issue which I think is tolerable for now: Developer manually written doc comments `///` will end up getting converted to line comments `//` on running scaffolding commands that modify this file. While the comments will still be retained, they will take on a different format. I think this minor hiccup is tolerable, I will open up another issue so that we can keep track of it an make developers aware of this peculiarity.

Extra changes:
- [Move important scaffold functions to the top of the module for easy access](https://github.com/holochain/scaffolding/pull/382/commits/f7c01e5f65ebb6773be8b8ec39b4559cdbbbaa3d)
- [Fix improper use of `bool.then_some`](https://github.com/holochain/scaffolding/pull/382/commits/114c708a5224739c9bf941eb913804b408706670)

---

Fixes #167 
Fixes https://github.com/holochain/Components/issues/47