### PR TITLE
feat: Improve `hc-scaffold entry-type` developer experience

### DIFF
--- a/src/scaffold/entry_type/definitions.rs
+++ b/src/scaffold/entry_type/definitions.rs
@@ -234,7 +234,9 @@ impl FromStr for FieldDefinition {
     fn from_str(fields_str: &str) -> Result<Self, Self::Err> {
         let mut str_path = fields_str.split(':');
 
-        let field_name = str_path.next().context(format!("field_name is missing from: {}", fields_str))?;
+        let field_name = str_path
+            .next()
+            .context(format!("field_name is missing from: {}", fields_str))?;
         check_case(field_name, "field_name", Case::Snake)?;
 
         let field_type_str = str_path.next().context(format!(
@@ -337,22 +339,19 @@ impl FromStr for EntryTypeReference {
     type Err = ScaffoldError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let sp: Vec<&str> = s.split(':').collect();
-        check_case(sp[0], "entry type reference", Case::Snake)?;
+        let mut str_path = s.split(':');
 
-        let reference_entry_hash = match sp.len() {
-            0 | 1 => false,
-            _ => match sp[1] {
-                "EntryHash" => true,
-                "ActionHash" => false,
-                _ => Err(ScaffoldError::InvalidArguments(String::from(
-                    "second argument for reference type must be \"EntryHash\" or \"ActionHash\"",
-                )))?,
-            },
-        };
+        let entry_type = str_path
+            .next()
+            .context(format!("Failed to parse entry_type from: {}", s))?;
+
+        let reference_entry_hash = str_path
+            .next()
+            .map(|v| matches!(v, "EntryHash"))
+            .unwrap_or_default();
 
         Ok(EntryTypeReference {
-            entry_type: sp[0].to_string().to_case(Case::Pascal),
+            entry_type: entry_type.to_case(Case::Pascal),
             reference_entry_hash,
         })
     }

--- a/src/scaffold/entry_type/definitions.rs
+++ b/src/scaffold/entry_type/definitions.rs
@@ -97,9 +97,19 @@ impl FieldType {
     }
 
     pub fn parse_enum(fields_str: &str) -> ScaffoldResult<FieldType> {
-        let sp: Vec<&str> = fields_str.split(':').collect();
-        let label = sp[3].to_string().to_case(Case::Pascal);
-        let variants = sp[4].split('.').map(|v| v.to_case(Case::Pascal)).collect();
+        let mut str_path = fields_str.split(':');
+
+        let variants = str_path
+            .next_back()
+            .context(format!("Enum variants missing from: {}", fields_str))?;
+        let variants = variants
+            .split('.')
+            .map(|v| v.to_case(Case::Pascal))
+            .collect::<Vec<_>>();
+        let label = str_path
+            .next_back()
+            .context(format!("Enum label missing from: {}", fields_str))?
+            .to_string();
 
         Ok(FieldType::Enum { label, variants })
     }

--- a/src/scaffold/entry_type/fields.rs
+++ b/src/scaffold/entry_type/fields.rs
@@ -1,336 +1,21 @@
-use std::{path::PathBuf, str::FromStr};
+use std::path::PathBuf;
 
+use colored::Colorize;
 use convert_case::{Case, Casing};
 use dialoguer::{theme::ColorfulTheme, Confirm, Select};
-use regex::Regex;
 
 use crate::{
     error::{ScaffoldError, ScaffoldResult},
     file_tree::{dir_content, FileTree},
+    reserved_words::check_for_reserved_words,
     scaffold::zome::ZomeFileTree,
-    utils::{
-        check_case, input_with_case, input_with_case_and_initial_text, input_with_custom_validation,
-    },
+    utils::{check_case, input_with_case, input_with_custom_validation},
 };
 
 use super::{
     definitions::{Cardinality, EntryTypeReference, FieldDefinition, FieldType, Referenceable},
     integrity::get_all_entry_types,
 };
-
-impl FromStr for FieldDefinition {
-    type Err = ScaffoldError;
-
-    fn from_str(fields_str: &str) -> Result<Self, Self::Err> {
-        let sp: Vec<&str> = fields_str.split(':').collect();
-
-        let field_name = sp[0].to_string();
-
-        check_case(&field_name, "field_name", Case::Snake)?;
-
-        let field_type_str = sp[1].to_string();
-
-        let vec_regex = Regex::new(r"Vec<(?P<a>(.)*)>\z").unwrap();
-        let option_regex = Regex::new(r"Option<(?P<a>(.)*)>\z").unwrap();
-
-        let (field_type, cardinality) = if vec_regex.is_match(field_type_str.as_str()) {
-            let field_type = vec_regex.replace(field_type_str.as_str(), "${a}");
-
-            if field_type == "Enum" {
-                (parse_enum(fields_str)?, Cardinality::Vector)
-            } else {
-                (
-                    FieldType::try_from(field_type.to_string())?,
-                    Cardinality::Vector,
-                )
-            }
-        } else if option_regex.is_match(field_type_str.as_str()) {
-            let field_type = option_regex.replace(field_type_str.as_str(), "${a}");
-
-            if field_type == "Enum" {
-                (parse_enum(fields_str)?, Cardinality::Option)
-            } else {
-                (
-                    FieldType::try_from(field_type.to_string())?,
-                    Cardinality::Option,
-                )
-            }
-        } else if field_type_str == "Enum" {
-            (parse_enum(fields_str)?, Cardinality::Single)
-        } else {
-            (
-                FieldType::try_from(field_type_str.to_string())?,
-                Cardinality::Single,
-            )
-        };
-
-        let widget = if sp.len() > 2 {
-            match sp[2] {
-                "" => None,
-                _ => Some(sp[2].to_string()),
-            }
-        } else {
-            None
-        };
-
-        let linked_from = match field_type {
-            FieldType::AgentPubKey => match sp.len() {
-                4 => Some(Referenceable::Agent {
-                    role: sp[3].to_string(),
-                }),
-                _ => None,
-            },
-            FieldType::EntryHash | FieldType::ActionHash => match sp.len() {
-                4 => Some(Referenceable::EntryType(EntryTypeReference {
-                    entry_type: sp[3].to_string(),
-                    reference_entry_hash: matches!(field_type, FieldType::EntryHash),
-                })),
-                _ => None,
-            },
-            _ => None,
-        };
-
-        Ok(FieldDefinition {
-            field_name,
-            field_type,
-            widget,
-            cardinality,
-            linked_from,
-        })
-    }
-}
-
-fn parse_enum(fields_str: &str) -> ScaffoldResult<FieldType> {
-    let sp: Vec<&str> = fields_str.split(':').collect();
-
-    let label = sp[3].to_string().to_case(Case::Pascal);
-
-    let variants = sp[4].split('.').map(|v| v.to_case(Case::Pascal)).collect();
-
-    Ok(FieldType::Enum { label, variants })
-}
-
-pub fn choose_widget(
-    field_type: &FieldType,
-    field_types_templates: &FileTree,
-) -> ScaffoldResult<Option<String>> {
-    let path = PathBuf::new().join(field_type.to_string());
-
-    match dir_content(field_types_templates, &path) {
-        Err(_) => Ok(None),
-        Ok(folders) => {
-            let widgets_that_can_render_this_type: Vec<String> = folders
-                .into_iter()
-                .filter(|(_key, value)| value.dir_content().is_some())
-                .map(|(key, _value)| key)
-                .map(|s| s.to_str().unwrap().to_string())
-                .collect();
-
-            if widgets_that_can_render_this_type.is_empty() {
-                return Ok(None);
-            }
-
-            let visible = Confirm::with_theme(&ColorfulTheme::default())
-                .with_prompt("Should this field be visible in the UI?")
-                .interact()?;
-
-            if !visible {
-                return Ok(None);
-            }
-
-            let selection = Select::with_theme(&ColorfulTheme::default())
-                .with_prompt("Choose widget to render this field:")
-                .default(0)
-                .items(&widgets_that_can_render_this_type[..])
-                .interact()?;
-
-            let widget_name = widgets_that_can_render_this_type[selection].clone();
-
-            Ok(Some(widget_name))
-        }
-    }
-}
-
-pub fn choose_field(
-    entry_type_name: &str,
-    zome_file_tree: &ZomeFileTree,
-    field_types_templates: &FileTree,
-    no_ui: bool,
-) -> ScaffoldResult<FieldDefinition> {
-    let field_types = FieldType::list();
-    let field_type_names: Vec<String> = field_types
-        .clone()
-        .into_iter()
-        .map(|s| s.to_string())
-        .collect();
-
-    let selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Choose field type:")
-        .default(0)
-        .items(&field_type_names[..])
-        .item("Option of...")
-        .item("Vector of...")
-        .interact()?;
-
-    // If user selected vector
-    let (cardinality, mut field_type) = if selection == field_type_names.len() {
-        let selection = Select::with_theme(&ColorfulTheme::default())
-            .with_prompt("Option of which field type?")
-            .default(0)
-            .items(&field_type_names[..])
-            .interact()?;
-
-        (Cardinality::Option, field_types[selection].clone())
-    } else if selection == field_type_names.len() + 1 {
-        let selection = Select::with_theme(&ColorfulTheme::default())
-            .with_prompt("Vector of which field type?")
-            .default(0)
-            .items(&field_type_names[..])
-            .interact()?;
-
-        (Cardinality::Vector, field_types[selection].clone())
-    } else {
-        (Cardinality::Single, field_types[selection].clone())
-    };
-
-    if let FieldType::Enum { .. } = field_type {
-        let label =
-            input_with_custom_validation("Enter the name of the enum:", |input: &String| {
-                if !input.is_case(Case::Pascal) {
-                    return Err(format!("Input must be {:?} case.", Case::Pascal));
-                }
-                if input.to_ascii_lowercase() == entry_type_name {
-                    return Err(format!(
-                        "Enum name: {input} conflicts with entry-type name: {entry_type_name}"
-                    ));
-                }
-                Ok(())
-            })?;
-
-        let mut variants: Vec<String> = Vec::new();
-
-        let mut another_field = true;
-
-        while another_field {
-            let variant = input_with_custom_validation(
-                "Enter the name of the next variant:",
-                |input: &String| {
-                    if !input.is_case(Case::Pascal) {
-                        return Err(format!("Input must be {:?} case.", Case::Pascal));
-                    }
-                    if variants.contains(input) {
-                        return Err(format!("{input} is already a variant of the enum"));
-                    }
-                    Ok(())
-                },
-            )?;
-            variants.push(variant);
-            another_field = Confirm::with_theme(&ColorfulTheme::default())
-                .with_prompt("Add another variant to the enum?")
-                .report(false)
-                .interact()?;
-        }
-
-        field_type = FieldType::Enum { label, variants };
-    }
-
-    let maybe_linked_from = match &field_type {
-        FieldType::AgentPubKey => {
-            let link_from = Confirm::with_theme(&ColorfulTheme::default())
-                .with_prompt(
-                    "Should a link from the AgentPubKey provided in this field also be created when entries of this type are created?"
-                )
-                .interact()?;
-
-            match link_from {
-                false => None,
-                true => {
-                    let role = input_with_case(&String::from(
-                        "Which role does this agent play in the relationship ? (eg. \"creator\", \"invitee\")",
-                    ), Case::Snake)?;
-                    Some(Referenceable::Agent { role })
-                }
-            }
-        }
-        FieldType::ActionHash | FieldType::EntryHash => {
-            let link_from = Confirm::with_theme(&ColorfulTheme::default())
-                    .with_prompt(
-                        format!(
-                            "Should a link from the {field_type} provided in this field also be created when entries of this type are created?",
-                        )
-                    )
-                    .interact()?;
-
-            match link_from {
-                false => None,
-                true => {
-                    let all_entry_types = get_all_entry_types(zome_file_tree)?.unwrap_or(vec![]);
-                    let mut all_options: Vec<String> = all_entry_types
-                        .clone()
-                        .into_iter()
-                        .map(|r| r.entry_type)
-                        .collect();
-
-                    if let Cardinality::Option | Cardinality::Vector = cardinality {
-                        all_options.push(format!(
-                            "{} (itself)",
-                            entry_type_name.to_case(Case::Pascal)
-                        ));
-                    }
-
-                    if all_options.is_empty() {
-                        return Err(ScaffoldError::NoEntryTypesDefFoundForIntegrityZome(
-                            zome_file_tree.dna_file_tree.dna_manifest.name(),
-                            zome_file_tree.zome_manifest.name.to_string(),
-                        ));
-                    }
-
-                    let selection = Select::with_theme(&ColorfulTheme::default())
-                        .with_prompt(String::from("Which entry type is this field referring to?"))
-                        .default(0)
-                        .items(&all_options[..])
-                        .interact()?;
-
-                    let reference_entry_hash = matches!(field_type, FieldType::EntryHash);
-
-                    match selection == all_entry_types.len() {
-                        true => Some(Referenceable::EntryType(EntryTypeReference {
-                            entry_type: entry_type_name.to_owned(),
-                            reference_entry_hash,
-                        })),
-                        false => Some(Referenceable::EntryType(EntryTypeReference {
-                            entry_type: all_entry_types[selection].entry_type.clone(),
-                            reference_entry_hash,
-                        })),
-                    }
-                }
-            }
-        }
-        _ => None,
-    };
-
-    let initial_text = match &maybe_linked_from {
-        Some(r) => r.field_name(&cardinality),
-        None => String::from(""),
-    };
-
-    let field_name: String =
-        input_with_case_and_initial_text(&String::from("Field name:"), Case::Snake, &initial_text)?;
-
-    let widget = if no_ui {
-        None
-    } else {
-        choose_widget(&field_type, field_types_templates)?
-    };
-
-    FieldDefinition::new(
-        field_name,
-        field_type,
-        widget,
-        cardinality,
-        maybe_linked_from,
-    )
-}
 
 pub fn choose_fields(
     entry_type_name: &str,
@@ -340,6 +25,7 @@ pub fn choose_fields(
 ) -> ScaffoldResult<Vec<FieldDefinition>> {
     let mut finished = false;
     let mut fields: Vec<FieldDefinition> = Vec::new();
+
     println!("\nWhich fields should the entry contain?\n");
 
     while !finished {
@@ -359,14 +45,261 @@ pub fn choose_fields(
     }
 
     println!(
-        "Chosen fields: {}
-",
+        "Chosen fields:\n {}",
         fields
             .iter()
-            .map(|f| f.field_name.clone())
+            .map(|f| format!("{}: {}", f.field_name.clone(), f.field_type))
             .collect::<Vec<String>>()
             .join(", ")
+            .italic()
     );
 
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt(
+            "Do you want to proceed with the current entry type or restart from the beginning?",
+        )
+        .item("Confirm")
+        .item("Restart")
+        .default(0)
+        .interact()?;
+
+    if selection == 1 {
+        return choose_fields(
+            entry_type_name,
+            zome_file_tree,
+            field_types_templates,
+            no_ui,
+        );
+    }
+
     Ok(fields)
+}
+
+fn choose_field(
+    entry_type_name: &str,
+    zome_file_tree: &ZomeFileTree,
+    field_types_templates: &FileTree,
+    no_ui: bool,
+) -> ScaffoldResult<FieldDefinition> {
+    let field_types = FieldType::list();
+    let field_type_names: Vec<String> = field_types
+        .clone()
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let field_name = input_with_custom_validation("Field name:", |input| {
+        if let Err(e) = check_case(&input, "field_name", Case::Snake) {
+            return Err(e.to_string());
+        }
+        if let Err(e) = check_for_reserved_words(&input) {
+            return Err(e.to_string());
+        }
+        Ok(())
+    })?;
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Choose field type:")
+        .default(0)
+        .items(&field_type_names[..])
+        .item("Option of...")
+        .item("Vector of...")
+        .interact()?;
+
+    // If user selected Vector of ...
+    let (cardinality, field_type) = if selection == field_type_names.len() {
+        let selection = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("Option of which field type?")
+            .default(0)
+            .items(&field_type_names[..])
+            .interact()?;
+
+        (Cardinality::Option, field_types[selection].clone())
+    // If user selected Option of ...
+    } else if selection == field_type_names.len() + 1 {
+        let selection = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("Vector of which field type?")
+            .default(0)
+            .items(&field_type_names[..])
+            .interact()?;
+
+        (Cardinality::Vector, field_types[selection].clone())
+    } else {
+        (Cardinality::Single, field_types[selection].clone())
+    };
+
+    if let FieldType::Enum { .. } = field_type {
+        let label =
+            input_with_custom_validation("Enter the name of the enum:", |input: String| {
+                if !input.is_case(Case::Pascal) {
+                    return Err(format!("Input must be {:?} case.", Case::Pascal));
+                }
+                if input.to_ascii_lowercase() == entry_type_name {
+                    return Err(format!(
+                        "Enum name: {input} conflicts with entry-type name: {entry_type_name}"
+                    ));
+                }
+                Ok(())
+            })?;
+
+        let mut variants = Vec::new();
+        let mut another_variant = true;
+
+        while another_variant {
+            let variant = input_with_custom_validation(
+                "Enter the name of the next variant:",
+                |input: String| {
+                    if !input.is_case(Case::Pascal) {
+                        return Err(format!("Input must be {:?} case.", Case::Pascal));
+                    }
+                    if variants.contains(&input) {
+                        return Err(format!("{input} is already a variant of the enum"));
+                    }
+                    Ok(())
+                },
+            )?;
+            variants.push(variant);
+            another_variant = Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt("Add another variant to the enum?")
+                .report(false)
+                .interact()?;
+        }
+
+        let widget = (!no_ui)
+            .then(|| choose_widget(&field_type, field_types_templates))
+            .transpose()?
+            .flatten();
+
+        return FieldDefinition::new(
+            label.to_case(Case::Snake),
+            FieldType::Enum { label, variants },
+            widget,
+            cardinality,
+            None,
+        );
+    }
+
+    let linked_from = match &field_type {
+        FieldType::AgentPubKey => {
+            let should_link_from_agent_pubkey = Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt(
+                    "Should a link from the AgentPubKey provided in this field also be created when entries of this type are created?"
+                )
+                .interact()?;
+
+            if should_link_from_agent_pubkey {
+                let role = input_with_case(
+                    "Which role does this agent play in the relationship ? (eg. \"creator\", \"invitee\")",
+                    Case::Snake
+                )?;
+                Some(Referenceable::Agent { role })
+            } else {
+                None
+            }
+        }
+        FieldType::ActionHash | FieldType::EntryHash => {
+            let should_link_from_hash_type = Confirm::with_theme(&ColorfulTheme::default())
+                    .with_prompt(
+                        format!(
+                            "Should a link from the {field_type} provided in this field also be created when entries of this type are created?",
+                        )
+                    )
+                    .interact()?;
+
+            if should_link_from_hash_type {
+                let all_entry_types = get_all_entry_types(zome_file_tree)?.unwrap_or_default();
+                let mut all_options: Vec<String> = all_entry_types
+                    .clone()
+                    .into_iter()
+                    .map(|r| r.entry_type)
+                    .collect();
+
+                if let Cardinality::Option | Cardinality::Vector = cardinality {
+                    all_options.push(format!(
+                        "{} (itself)",
+                        entry_type_name.to_case(Case::Pascal)
+                    ));
+                }
+
+                if all_options.is_empty() {
+                    return Err(ScaffoldError::NoEntryTypesDefFoundForIntegrityZome(
+                        zome_file_tree.dna_file_tree.dna_manifest.name(),
+                        zome_file_tree.zome_manifest.name.to_string(),
+                    ));
+                }
+
+                let selection = Select::with_theme(&ColorfulTheme::default())
+                    .with_prompt(String::from("Which entry type is this field referring to?"))
+                    .default(0)
+                    .items(&all_options[..])
+                    .interact()?;
+
+                let reference_entry_hash = matches!(field_type, FieldType::EntryHash);
+
+                // if the entry links to itself
+                if selection == all_entry_types.len() {
+                    Some(Referenceable::EntryType(EntryTypeReference {
+                        entry_type: entry_type_name.to_owned(),
+                        reference_entry_hash,
+                    }))
+                } else {
+                    Some(Referenceable::EntryType(EntryTypeReference {
+                        entry_type: all_entry_types[selection].entry_type.clone(),
+                        reference_entry_hash,
+                    }))
+                }
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+
+    let widget = (!no_ui)
+        .then(|| choose_widget(&field_type, field_types_templates))
+        .transpose()?
+        .flatten();
+
+    FieldDefinition::new(field_name, field_type, widget, cardinality, linked_from)
+}
+
+fn choose_widget(
+    field_type: &FieldType,
+    field_types_templates: &FileTree,
+) -> ScaffoldResult<Option<String>> {
+    let path = PathBuf::new().join(field_type.to_string());
+
+    match dir_content(field_types_templates, &path) {
+        Ok(folders) => {
+            let widgets_that_can_render_this_type: Vec<String> = folders
+                .into_iter()
+                .filter(|(_key, value)| value.dir_content().is_some())
+                .map(|(key, _value)| key)
+                .map(|s| s.to_str().unwrap().to_string())
+                .collect();
+
+            if widgets_that_can_render_this_type.is_empty() {
+                return Ok(None);
+            }
+
+            let should_scaffold_ui = Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt("Should UI be generated for this field?")
+                .interact()?;
+
+            if !should_scaffold_ui {
+                return Ok(None);
+            }
+
+            let selection = Select::with_theme(&ColorfulTheme::default())
+                .with_prompt("Choose widget to render this field:")
+                .default(0)
+                .items(&widgets_that_can_render_this_type[..])
+                .interact()?;
+
+            let widget_name = widgets_that_can_render_this_type[selection].clone();
+
+            Ok(Some(widget_name))
+        }
+        Err(_) => Ok(None),
+    }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Improves enum field_type selection, the field_name is assumed to be the label of the enum to avoid unnecessary prompts (closes https://github.com/holochain/Components/issues/68)
- Updates how we prompt users for field types, rather than asking them for the type first, we now ask them for the name of the field then the type.
- Add the option that allows the user to re-start building of their entry-type through a recursive call to `choose_fields`, incase there was an error or mistake when creating a field for their entry type. This is a first step towards the replay functionality, further improvements to this can be made with (a) separate PR(s) i.e to modify/add/delete specific fields rather than starting over (first of https://github.com/holochain/Components/issues/76 and https://github.com/holochain/scaffolding/issues/53)
- Refactor the `input_with_custom_validation` function to continue to re-prompt the user for input incase the validation fails rather than exiting the operation altogether (first step towards addressing https://github.com/holochain/scaffolding/issues/387)
- Greatly refactor the `FieldDefinition` and `EntryTypeReference` parsing logic to enhance resilience and better error handling

selection; refactor FieldType parsing