### PR TITLE
fix: Optimize nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,8 @@
           };
 
           devShells.default = pkgs.mkShell {
+            inputsFrom = [ inputs'.holonix.devShells ];
+
             packages = (with inputs'.holonix.packages; [
               holochain
               lair-keystore
@@ -120,7 +122,10 @@
           };
 
           devShells.ci = pkgs.mkShell {
-            packages = [ self'.packages.hc-scaffold ];
+            inputsFrom = [ self'.devShells.default ];
+            packages = [
+              self'.packages.hc-scaffold
+            ];
           };
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -101,8 +101,6 @@
           };
 
           devShells.default = pkgs.mkShell {
-            inputsFrom = [ inputs'.holonix.devShells ];
-
             packages = (with inputs'.holonix.packages; [
               holochain
               lair-keystore
@@ -122,10 +120,7 @@
           };
 
           devShells.ci = pkgs.mkShell {
-            inputsFrom = [ self'.devShells.default ];
-            packages = [
-              self'.packages.hc-scaffold
-            ];
+            packages = [ self'.packages.hc-scaffold ];
           };
         };
       };

--- a/src/templates/collection.rs
+++ b/src/templates/collection.rs
@@ -28,7 +28,7 @@ pub struct ScaffoldCollectionData {
 }
 
 // TODO: group some params into a new-type or prefer builder pattern
-#[allow(clippy::too_many_arguments)]
+#[allow(unknown_lints, clippy::too_many_arguments, clippy::manual_inspect)]
 pub fn scaffold_collection_templates(
     mut app_file_tree: FileTree,
     template_file_tree: &FileTree,

--- a/src/templates/entry_type.rs
+++ b/src/templates/entry_type.rs
@@ -25,7 +25,7 @@ pub struct ScaffoldEntryTypeData<'a> {
 }
 
 // TODO: group some params into a new-type or prefer builder pattern
-#[allow(clippy::too_many_arguments)]
+#[allow(unknown_lints, clippy::too_many_arguments, clippy::manual_inspect)]
 pub fn scaffold_entry_type_templates(
     mut app_file_tree: FileTree,
     template_file_tree: &FileTree,

--- a/src/templates/link_type.rs
+++ b/src/templates/link_type.rs
@@ -26,7 +26,7 @@ pub struct ScaffoldLinkTypeData<'a> {
 }
 
 // TODO: group some params into a new-type or prefer builder pattern
-#[allow(clippy::too_many_arguments)]
+#[allow(unknown_lints, clippy::too_many_arguments, clippy::manual_inspect)]
 pub fn scaffold_link_type_templates(
     mut app_file_tree: FileTree,
     template_file_tree: &FileTree,


### PR DESCRIPTION
This PR optimizes the local development nix flake to only include nixpkgs it requires in its devshell