### PR TITLE
fix: Fix misplaced doc comments

### DIFF
--- a/src/file_tree.rs
+++ b/src/file_tree.rs
@@ -82,8 +82,6 @@ pub fn insert_file(
     let mut folder_path = file_path.to_path_buf();
     folder_path.pop();
 
-    let content = convert_rust_line_to_doc_comments(file_path, content);
-
     insert_file_tree_in_dir(
         file_tree,
         &folder_path,
@@ -232,7 +230,7 @@ pub fn map_rust_files<F: Fn(PathBuf, syn::File) -> ScaffoldResult<syn::File> + C
 /// otherwise returns the original content unchanged.
 fn convert_rust_line_to_doc_comments(file_path: &Path, content: &str) -> String {
     if file_path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
-        let re = Regex::new(r"^\/\/[^\/]|[^\/]\/\/[^\/]").expect("Failed to create regex");
+        let re = Regex::new(r"(?:^|[^:])/(/[^/])").expect("Failed to create regex");
         content
             .lines()
             .map(|line| re.replace_all(line, "/// ").into_owned() + "\n")

--- a/src/scaffold/entry_type/integrity.rs
+++ b/src/scaffold/entry_type/integrity.rs
@@ -209,7 +209,7 @@ pub fn render_entry_definition_file(
 
     let validate_update_result = if crud.update {
         quote! {
-            // TODO: add the appropriate validation rules
+            /// TODO: add the appropriate validation rules
             Ok(ValidateCallbackResult::Valid)
         }
     } else {
@@ -236,7 +236,7 @@ pub fn render_entry_definition_file(
 
     let validate_delete_result = if crud.delete {
         quote! {
-            // TODO: add the appropriate validation rules
+            /// TODO: add the appropriate validation rules
             Ok(ValidateCallbackResult::Valid)
         }
     } else {
@@ -339,7 +339,7 @@ pub fn render_entry_definition_file(
         ) -> ExternResult<ValidateCallbackResult> {
             #(#deps_validation)*
 
-            // TODO: add the appropriate validation rules
+            /// TODO: add the appropriate validation rules
             Ok(ValidateCallbackResult::Valid)
         }
 

--- a/src/scaffold/entry_type/integrity.rs
+++ b/src/scaffold/entry_type/integrity.rs
@@ -209,7 +209,7 @@ pub fn render_entry_definition_file(
 
     let validate_update_result = if crud.update {
         quote! {
-            /// TODO: add the appropriate validation rules
+            // TODO: add the appropriate validation rules
             Ok(ValidateCallbackResult::Valid)
         }
     } else {
@@ -236,7 +236,7 @@ pub fn render_entry_definition_file(
 
     let validate_delete_result = if crud.delete {
         quote! {
-            /// TODO: add the appropriate validation rules
+            // TODO: add the appropriate validation rules
             Ok(ValidateCallbackResult::Valid)
         }
     } else {
@@ -339,7 +339,7 @@ pub fn render_entry_definition_file(
         ) -> ExternResult<ValidateCallbackResult> {
             #(#deps_validation)*
 
-            /// TODO: add the appropriate validation rules
+            // TODO: add the appropriate validation rules
             Ok(ValidateCallbackResult::Valid)
         }
 

--- a/src/scaffold/link_type/integrity.rs
+++ b/src/scaffold/link_type/integrity.rs
@@ -305,7 +305,7 @@ fn validate_referenceable(
 
             if entry_type.reference_entry_hash {
                 quote! {
-                    /// Check the entry type for the given entry hash
+                    // Check the entry type for the given entry hash
                     let entry_hash = #address_ident.into_entry_hash().ok_or(wasm_error!(WasmErrorInner::Guest("No entry hash associated with link".to_string())))?;
                     let entry = must_get_entry(entry_hash)?.content;
 
@@ -313,7 +313,7 @@ fn validate_referenceable(
                 }
             } else {
                 quote! {
-                    /// Check the entry type for the given action hash
+                    // Check the entry type for the given action hash
                     let action_hash = #address_ident.into_action_hash().ok_or(wasm_error!(
                         WasmErrorInner::Guest("No action hash associated with link".to_string())
                     ))?;

--- a/src/scaffold/zome.rs
+++ b/src/scaffold/zome.rs
@@ -454,7 +454,7 @@ pub fn scaffold_coordinator_zome_in_path(
     let file_tree = add_common_zome_dependencies_to_workspace_cargo(dna_file_tree.file_tree())?;
     let mut file_tree = add_workspace_path_dependency(file_tree, zome_name, &path.join(zome_name))?;
 
-    let initial_lib_rs = &coordinator::initial_lib_rs(dependencies);
+    let initial_lib_rs = coordinator::initial_lib_rs(dependencies);
 
     let zome: FileTree = dir! {
         "Cargo.toml" => file!(coordinator::initial_cargo_toml(zome_name, dependencies)),

--- a/src/scaffold/zome/coordinator.rs
+++ b/src/scaffold/zome/coordinator.rs
@@ -72,9 +72,9 @@ pub fn initial_lib_rs(dependencies: Option<&Vec<String>>) -> TokenStream {
         pub enum Signal {}
 
         /// Whenever an action is committed, we emit a signal to the UI elements to reactively update them
-        /// Don't modify the for loop if you want the scaffolding tool to generate appropriate signals for your entries and links
         #[hdk_extern(infallible)]
         pub fn post_commit(committed_actions: Vec<SignedActionHashed>) {
+            /// Don't modify the for loop if you want the scaffolding tool to generate appropriate signals for your entries and links
             for action in committed_actions {
                 if let Err(err) = signal_action(action) {
                     error!("Error signaling new action: {:?}", err);

--- a/src/scaffold/zome/coordinator.rs
+++ b/src/scaffold/zome/coordinator.rs
@@ -72,9 +72,9 @@ pub fn initial_lib_rs(dependencies: Option<&Vec<String>>) -> TokenStream {
         pub enum Signal {}
 
         /// Whenever an action is committed, we emit a signal to the UI elements to reactively update them
+        /// Don't modify the for loop if you want the scaffolding tool to generate appropriate signals for your entries and links
         #[hdk_extern(infallible)]
         pub fn post_commit(committed_actions: Vec<SignedActionHashed>) {
-            /// Don't modify this loop if you want the scaffolding tool to generate appropriate signals for your entries and links
             for action in committed_actions {
                 if let Err(err) = signal_action(action) {
                     error!("Error signaling new action: {:?}", err);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -76,20 +76,16 @@ fn get_folder_names(folder: &BTreeMap<OsString, FileTree>) -> Vec<String> {
 #[inline]
 /// "yes" or "no" input dialog, with the option to specify a recommended answer (yes = true, no = false)
 pub fn input_yes_or_no(prompt: &str, recommended: Option<bool>) -> ScaffoldResult<bool> {
-    let yes_recommended = if recommended == Some(true) {
-        " (recommended)"
-    } else {
-        ""
-    };
-    let no_recommended = if recommended == Some(false) {
-        " (recommended)"
-    } else {
-        ""
-    };
+    let yes_recommended = (recommended == Some(true))
+        .then_some("(recommended)")
+        .unwrap_or_default();
+    let no_recommended = (recommended == Some(false))
+        .then_some("(recommended)")
+        .unwrap_or_default();
 
     let items = [
-        format!("Yes{}", yes_recommended),
-        format!("No{}", no_recommended),
+        format!("Yes {}", yes_recommended),
+        format!("No {}", no_recommended),
     ];
 
     let selection = Select::with_theme(&ColorfulTheme::default())


### PR DESCRIPTION
Fixes #406
Fixes #413 (ensures `//` in URLs are not inadvertently replaced)

This PR also contains some additional code refactors to how the validate function codegen is handled