### PR TITLE
fix: Skip writing scaffold config for nixified custom templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,4 +50,9 @@ itertools = "0.13.0"
 colored = "2.1.0"
 dprint-plugin-typescript = "0.91.1"
 markup_fmt = "0.10.0"
-git2 = { version = "0.19.0", default-features = false, features = ["https", "ssh_key_from_memory", "vendored-libgit2", "vendored-openssl"] }
+git2 = { version = "0.19.0", default-features = false, features = [
+  "https",
+  "ssh_key_from_memory",
+  "vendored-libgit2",
+  "vendored-openssl",
+] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,11 @@ pub struct HcScaffold {
     /// Or a path to a custom template
     template: Option<TemplateType>,
 
+    #[structopt(long)]
+    /// Skip reading from `hcScaffold` configurations. Largely useful for hApps built with
+    /// nix-wrapper based custom templates
+    skip_config_check: bool,
+
     #[structopt(subcommand)]
     command: HcScaffoldCommand,
 }
@@ -48,7 +53,11 @@ pub enum HcScaffoldCommand {
 impl HcScaffold {
     pub async fn run(self) -> anyhow::Result<()> {
         let current_dir = std::env::current_dir()?;
-        let scaffold_config = ScaffoldConfig::from_package_json_path(&current_dir)?;
+        let scaffold_config = if !self.skip_config_check {
+            ScaffoldConfig::from_package_json_path(&current_dir)?
+        } else {
+            None
+        };
         let template_type = self.get_template_type(&current_dir, scaffold_config.as_ref())?;
 
         match self.command {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,11 +27,6 @@ pub struct HcScaffold {
     /// Or a path to a custom template
     template: Option<TemplateType>,
 
-    #[structopt(long)]
-    /// Skip reading from `hcScaffold` configurations. Largely useful for hApps built with
-    /// nix-wrapper based custom templates
-    skip_config_check: bool,
-
     #[structopt(subcommand)]
     command: HcScaffoldCommand,
 }
@@ -53,11 +48,7 @@ pub enum HcScaffoldCommand {
 impl HcScaffold {
     pub async fn run(self) -> anyhow::Result<()> {
         let current_dir = std::env::current_dir()?;
-        let scaffold_config = if !self.skip_config_check {
-            ScaffoldConfig::from_package_json_path(&current_dir)?
-        } else {
-            None
-        };
+        let scaffold_config = ScaffoldConfig::from_package_json_path(&current_dir)?;
         let template_type = self.get_template_type(&current_dir, scaffold_config.as_ref())?;
 
         match self.command {

--- a/src/cli/example.rs
+++ b/src/cli/example.rs
@@ -270,11 +270,11 @@ impl Example {
         };
 
         let ScaffoldedTemplate {
-            file_tree,
+            mut file_tree,
             next_instructions,
         } = scaffold_example(file_tree, package_manager, &template_file_tree, &example)?;
 
-        let file_tree = ScaffoldConfig::write_to_package_json(file_tree, template_type)?;
+        ScaffoldConfig::write_to_package_json(&mut file_tree, template_type)?;
 
         build_file_tree(file_tree, &app_dir)?;
 

--- a/src/cli/web_app.rs
+++ b/src/cli/web_app.rs
@@ -100,7 +100,7 @@ impl WebApp {
         )?;
 
         if !template_type.is_nixified_custom_template() {
-             ScaffoldConfig::write_to_package_json(&mut file_tree, template_type)?;
+            ScaffoldConfig::write_to_package_json(&mut file_tree, template_type)?;
         }
 
         build_file_tree(file_tree, &app_folder)?;

--- a/src/cli/web_app.rs
+++ b/src/cli/web_app.rs
@@ -88,7 +88,7 @@ impl WebApp {
         };
 
         let ScaffoldedTemplate {
-            file_tree,
+            mut file_tree,
             next_instructions,
         } = scaffold_web_app(
             &name,
@@ -99,7 +99,9 @@ impl WebApp {
             self.holo_enabled,
         )?;
 
-        let file_tree = ScaffoldConfig::write_to_package_json(file_tree, template_type)?;
+        if !template_type.is_nixified_custom_template() {
+             ScaffoldConfig::write_to_package_json(&mut file_tree, template_type)?;
+        }
 
         build_file_tree(file_tree, &app_folder)?;
 

--- a/src/scaffold/config.rs
+++ b/src/scaffold/config.rs
@@ -33,15 +33,15 @@ impl ScaffoldConfig {
     }
 
     pub fn write_to_package_json(
-        mut web_app_file_tree: FileTree,
+        web_app_file_tree: &mut FileTree,
         template_type: &TemplateType,
-    ) -> ScaffoldResult<FileTree> {
+    ) -> ScaffoldResult<()> {
         let config = ScaffoldConfig {
             template: template_type.clone(),
         };
         let package_json_path = PathBuf::from("package.json");
 
-        map_file(&mut web_app_file_tree, &package_json_path, |c| {
+        map_file(web_app_file_tree, &package_json_path, |c| {
             let original_content = c.clone();
             let json = serde_json::from_str::<Value>(&c)?;
             let json = match json {
@@ -59,6 +59,6 @@ impl ScaffoldConfig {
             Ok(json)
         })?;
 
-        Ok(web_app_file_tree)
+        Ok(())
     }
 }

--- a/src/scaffold/web_app/template_type.rs
+++ b/src/scaffold/web_app/template_type.rs
@@ -123,6 +123,14 @@ impl TemplateType {
             .interact()?;
         Ok(frameworks[selection].clone())
     }
+
+    /// Checks whether the custom template'path is a path to a nix store
+    pub fn is_nixified_custom_template(&self) -> bool {
+        if let TemplateType::Custom(path) = self {
+            return path.starts_with("/nix/store/");
+        }
+        false
+    }
 }
 
 impl From<PathBuf> for TemplateType {


### PR DESCRIPTION
~This PR introduces a global `--skip-config-check` flag that does as the name suggests, to provide an option to skip reading from `hcScaffold` config in the root package.json file. Using this flag will be mostly beneficial to users who scaffolded their hApps with a nix wrapper based custom template.~

This PR skips writing scaffold configs for web-apps or examples scaffolded from nixified custom templates

Closes #247 