### PR TITLE
chore: Revert update to vite-plugin-svelte

### DIFF
--- a/templates/ui-frameworks/svelte/web-app/ui/package.json.hbs
+++ b/templates/ui-frameworks/svelte/web-app/ui/package.json.hbs
@@ -18,7 +18,7 @@
     "@msgpack/msgpack": "^2.8.0"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.1.2",
+    "@sveltejs/vite-plugin-svelte": "^2.5.3",
     "@tsconfig/svelte": "^3.0.0",
     "bestzip": "^2.2.1",
     "rimraf": "^5.0.10",


### PR DESCRIPTION
This reverts commit 981b106a1e5c7bcf46a43d128645a256d6074d68. Seems to introduce a packaging conflict.