### PR TITLE
Revert update to vite-plugin-svelte for 0.4

### DIFF
--- a/templates/ui-frameworks/svelte/web-app/ui/package.json.hbs
+++ b/templates/ui-frameworks/svelte/web-app/ui/package.json.hbs
@@ -18,7 +18,7 @@
     "@msgpack/msgpack": "^2.8.0"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.1.2",
+    "@sveltejs/vite-plugin-svelte": "^2.0.2",
     "@tsconfig/svelte": "^3.0.0",
     "bestzip": "^2.2.0",
     "rimraf": "^5.0.7",


### PR DESCRIPTION
This reverts commit 3d80904fe65b4d9e78cc40af509a1623d7f0da17. It seems to introduce a packaging conflict.