### PR TITLE
Switch playground source to nix

### DIFF
--- a/src/scaffold/app/nix.rs
+++ b/src/scaffold/app/nix.rs
@@ -33,6 +33,8 @@ pub fn flake_nix(holo_enabled: bool, package_manager: &PackageManager) -> FileTr
 
     nixpkgs.follows = "holonix/nixpkgs";
     flake-parts.follows = "holonix/flake-parts";
+
+    playground.url = "github:darksoil-studio/holochain-playground?ref=main-0.4";
     {}
   }};
 
@@ -47,6 +49,7 @@ pub fn flake_nix(holo_enabled: bool, package_manager: &PackageManager) -> FileTr
         packages = (with pkgs; [
           nodejs_20
           binaryen
+          inputs'.playground.packages.hc-playground
           {}
           {}
         ]);

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -18,8 +18,3 @@ pub const HDK_VERSION: &str = "0.4.0";
 
 /// crates.io <https://crates.io/crates/holochain/versions>
 pub const HOLOCHAIN_VERSION: &str = "0.4.0";
-
-/// source: <https://github.com/darksoil-studio/holochain-playground/tree/main/packages/cli/server>
-///
-/// npm: <https://www.npmjs.com/package/@holochain-playground/cli>
-pub const HOLOCHAIN_PLAYGROUND_CLI_VERSION: &str = "^0.300.0-rc.0";

--- a/templates/generic/web-app/README.md.hbs
+++ b/templates/generic/web-app/README.md.hbs
@@ -56,4 +56,4 @@ This repository is using these tools:
 - [hc](https://github.com/holochain/holochain/tree/develop/crates/hc): Holochain CLI to easily manage Holochain development instances.
 - [@holochain/tryorama](https://www.npmjs.com/package/@holochain/tryorama): test framework.
 - [@holochain/client](https://www.npmjs.com/package/@holochain/client): client library to connect to Holochain from the UI.
-- [@holochain-playground/cli](https://www.npmjs.com/package/@holochain-playground/cli): introspection tooling to understand what's going on in the Holochain nodes.
+- [hc playground](https://github.com/darksoil-studio/holochain-playground): introspection tooling to understand what's going on in the Holochain nodes.

--- a/templates/generic/web-app/package.json.hbs
+++ b/templates/generic/web-app/package.json.hbs
@@ -7,15 +7,15 @@
   ],
   "scripts": {
     "start": "AGENTS=${AGENTS:-2} BOOTSTRAP_PORT=$(get-port) SIGNAL_PORT=$(get-port) {{(package_manager_command package_manager "network" null)}}",
-    "network": "hc sandbox clean && {{(package_manager_command package_manager "build:happ" null)}} && UI_PORT=$(get-port) concurrently \"{{(package_manager_command package_manager "start" "ui")}}\" \"{{(package_manager_command package_manager "launch:happ" null)}}\" \"holochain-playground\"",
+    "network": "hc sandbox clean && {{(package_manager_command package_manager "build:happ" null)}} && UI_PORT=$(get-port) concurrently \"{{(package_manager_command package_manager "start" "ui")}}\" \"{{(package_manager_command package_manager "launch:happ" null)}}\" \"hc playground\"",
     "test": "{{(package_manager_command package_manager "build:zomes" null)}} && hc app pack workdir --recursive && {{(package_manager_command package_manager "test" "tests")}}",
     "launch:happ": "hc-spin -n $AGENTS --ui-port $UI_PORT workdir/{{app_name}}.happ",
     "start:tauri": "AGENTS=${AGENTS:-2} BOOTSTRAP_PORT=$(get-port) SIGNAL_PORT=$(get-port) {{(package_manager_command package_manager "network:tauri" null)}}",
-    "network:tauri": "hc sandbox clean && {{(package_manager_command package_manager "build:happ" null)}} && UI_PORT=$(get-port) concurrently \"{{(package_manager_command package_manager "start" "ui")}}\" \"{{(package_manager_command package_manager "launch:tauri" null)}}\" \"holochain-playground\"",
+    "network:tauri": "hc sandbox clean && {{(package_manager_command package_manager "build:happ" null)}} && UI_PORT=$(get-port) concurrently \"{{(package_manager_command package_manager "start" "ui")}}\" \"{{(package_manager_command package_manager "launch:tauri" null)}}\" \"hc playground\"",
     "launch:tauri": "concurrently \"hc run-local-services --bootstrap-port $BOOTSTRAP_PORT --signal-port $SIGNAL_PORT\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/{{app_name}}.happ --ui-port $UI_PORT network --bootstrap http://127.0.0.1:\"$BOOTSTRAP_PORT\" webrtc ws://127.0.0.1:\"$SIGNAL_PORT\"\"",
   {{#if holo_enabled}}
     "start:holo": "AGENTS=${AGENTS:-2} {{(package_manager_command package_manager "network:holo" null)}}",
-    "network:holo": "{{(package_manager_command package_manager "build:happ" null)}} && UI_PORT=$(get-port) concurrently \"{{(package_manager_command package_manager "launch:holo-dev-server" null)}}\" \"holochain-playground ws://localhost:4444\" \"concurrently-repeat 'VITE_APP_CHAPERONE_URL=http://localhost:24274 VITE_APP_IS_HOLO=true {{(package_manager_command package_manager "start" "ui")}}' $AGENTS\"",
+    "network:holo": "{{(package_manager_command package_manager "build:happ" null)}} && UI_PORT=$(get-port) concurrently \"{{(package_manager_command package_manager "launch:holo-dev-server" null)}}\" \"hc playground ws://localhost:4444\" \"concurrently-repeat 'VITE_APP_CHAPERONE_URL=http://localhost:24274 VITE_APP_IS_HOLO=true {{(package_manager_command package_manager "start" "ui")}}' $AGENTS\"",
     "launch:holo-dev-server": "holo-dev-server workdir/{{app_name}}.happ",
   {{/if}}
   {{#if (eq package_manager "pnpm")}}
@@ -26,7 +26,6 @@
     "build:zomes": "cargo build --release --target wasm32-unknown-unknown"
   },
   "devDependencies": {
-    "@holochain-playground/cli": "{{holochain_playground_cli_version}}",
     "@holochain/hc-spin": "{{hc_spin_version}}",
     "concurrently": "^6.5.1",
   {{#if holo_enabled}}


### PR DESCRIPTION
I won't publish the cli for the playground to npm anymore, I've switched to it being available as nix package. This PR makes the scaffolding tool consume the playground correctly for 0.4 again.

People in Dev.HC have found issues because the scaffolded apps have playground for 0.3 and it doesn't work well with 0.4.