### PR TITLE
fix(svelte): Ensure client is loaded before use

### DIFF
--- a/templates/ui-frameworks/svelte/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case collection_name}}.svelte.hbs
+++ b/templates/ui-frameworks/svelte/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case collection_name}}.svelte.hbs
@@ -1,72 +1,78 @@
 <script lang="ts">
-import { onMount, getContext } from 'svelte';
-import type {
-  EntryHash,
-  Record,
-  AgentPubKey,
-  ActionHash,
-  Link,
-  AppClient,
-  NewEntryAction,
-  HolochainError,
-} from '@holochain/client';
-import { SignalType } from '@holochain/client'
-import { type ClientContext, clientContext } from '../../contexts';
+import { onMount } from 'svelte';
+import type { EntryHash, Record, AgentPubKey, ActionHash, Link, NewEntryAction, HolochainError } from '@holochain/client';
+import { SignalType } from '@holochain/client';
+import { getClient } from "../../contexts";
 import {{pascal_case referenceable.name}}Detail from './{{pascal_case referenceable.name}}Detail.svelte';
 import type { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
-
-let client: AppClient;
-const appClientContext = getContext<ClientContext>(clientContext);
-
-let hashes: Array<{{referenceable.hash_type}}> = [];
-let loading = false;
-let error: any = undefined;
 
 {{#if (eq collection_type.type "ByAuthor")}}
 export let author: AgentPubKey;
 {{/if}}
-$: hashes, loading, error;
 
-onMount(async () => {
-  {{#if (eq collection_type.type "ByAuthor")}}
-    if (!author) {
-      throw new Error(`The author input is required for the {{pascal_case collection_name}} element`);
-    }
-  {{/if}}
-  client = await appClientContext.getClient();
-  await fetch{{pascal_case (plural referenceable.name)}}();
-  client.on('signal', signal => {
-    if (!(SignalType.App in signal)) return;
-    if (signal.App.zome_name !== '{{coordinator_zome_manifest.name}}') return;
-    const payload = signal.App.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
-    if (payload.type !== 'EntryCreated') return;
-    if (payload.app_entry.type !== '{{pascal_case referenceable.name}}') return;
-{{#if (eq collection_type.type "ByAuthor")}}
-    if (author.toString() !== client.myPubKey.toString()) return;
-{{/if}}
-    hashes = [...hashes, {{#if (eq referenceable.hash_type "ActionHash")}}payload.action.hashed.hash{{else}}(payload.action.hashed.content as NewEntryAction).entry_hash{{/if}}];
-  });
-});
+const clientStore = getClient();
+
+let hashes: Array<{{referenceable.hash_type}}> = [];
+let loading = false;
+let error: HolochainError | undefined = undefined;
 
 async function fetch{{pascal_case (plural referenceable.name)}}() {
   loading = true;
   try {
-    const links: Array<Link> = await client.callZome({
+    const links: Array<Link> = await client?.callZome({
       role_name: '{{dna_role_name}}',
       zome_name: '{{snake_case coordinator_zome_manifest.name}}',
       fn_name: 'get_{{snake_case collection_name}}',
-      {{#if (eq collection_type.type "ByAuthor")}}payload: author,{{/if}}
+      {{#if (eq collection_type.type "ByAuthor")}}
+      payload: author,
+      {{/if}}
     });
-    if (links.length) {
+
+    if (links?.length) {
       hashes = links.map(l => l.target);
     }
-    hashes = links.map(l => l.target);
   } catch (e) {
     error = e as HolochainError;
   } finally {
     loading = false;
   }
 }
+
+function handleSignal(signal: any) {
+  if (!(SignalType.App in signal)) return;
+  if (signal.App.zome_name !== '{{coordinator_zome_manifest.name}}') return;
+  const payload = signal.App.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
+  if (payload.type !== 'EntryCreated') return;
+  if (payload.app_entry.type !== '{{pascal_case referenceable.name}}') return;
+
+  {{#if (eq collection_type.type "ByAuthor")}}
+  if (author.toString() !== $clientStore.client?.myPubKey.toString()) return;
+  {{/if}}
+
+  const newHash = {{#if (eq referenceable.hash_type "ActionHash")}}
+    payload.action.hashed.hash
+  {{else}}
+    (payload.action.hashed.content as NewEntryAction).entry_hash
+  {{/if}};
+
+  hashes = [...hashes, newHash];
+}
+
+onMount(async () => {
+  {{#if (eq collection_type.type "ByAuthor")}}
+  if (!author) {
+    throw new Error(`The author input is required for the {{pascal_case collection_name}} element`);
+  }
+  {{/if}}
+
+  if ($clientStore.client) {
+    await fetch{{pascal_case (plural referenceable.name)}}();
+    $clientStore.client.on('signal', handleSignal);
+  }
+});
+
+$: ({ client } = $clientStore);
+$: if (client) fetch{{pascal_case (plural referenceable.name)}}();
 </script>
 
 {#if loading}

--- a/templates/ui-frameworks/svelte/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case collection_name}}.svelte.hbs
+++ b/templates/ui-frameworks/svelte/collection/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case collection_name}}.svelte.hbs
@@ -1,7 +1,6 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import type { EntryHash, Record, AgentPubKey, ActionHash, Link, NewEntryAction, HolochainError } from '@holochain/client';
-import { SignalType } from '@holochain/client';
 import { getClient } from "../../contexts";
 import {{pascal_case referenceable.name}}Detail from './{{pascal_case referenceable.name}}Detail.svelte';
 import type { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
@@ -39,23 +38,15 @@ async function fetch{{pascal_case (plural referenceable.name)}}() {
 }
 
 function handleSignal(signal: any) {
-  if (!(SignalType.App in signal)) return;
-  if (signal.App.zome_name !== '{{coordinator_zome_manifest.name}}') return;
-  const payload = signal.App.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
+  if (signal.type !== "app") return;
+  if (signal.value.zome_name !== '{{coordinator_zome_manifest.name}}') return;
+  const payload = signal.value.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
   if (payload.type !== 'EntryCreated') return;
   if (payload.app_entry.type !== '{{pascal_case referenceable.name}}') return;
-
-  {{#if (eq collection_type.type "ByAuthor")}}
-  if (author.toString() !== $clientStore.client?.myPubKey.toString()) return;
-  {{/if}}
-
-  const newHash = {{#if (eq referenceable.hash_type "ActionHash")}}
-    payload.action.hashed.hash
-  {{else}}
-    (payload.action.hashed.content as NewEntryAction).entry_hash
-  {{/if}};
-
-  hashes = [...hashes, newHash];
+{{#if (eq collection_type.type "ByAuthor")}}
+  if (author.toString() !== client.myPubKey.toString()) return;
+{{/if}}
+  hashes = [...hashes, {{#if (eq referenceable.hash_type "ActionHash")}}payload.action.hashed.hash{{else}}(payload.action.hashed.content as NewEntryAction).entry_hash{{/if}}];
 }
 
 onMount(async () => {

--- a/templates/ui-frameworks/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/Create{{pascal_case entry_type.name}}.svelte.hbs
+++ b/templates/ui-frameworks/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/Create{{pascal_case entry_type.name}}.svelte.hbs
@@ -1,20 +1,18 @@
 <script lang="ts">
-import { createEventDispatcher, getContext, onMount } from 'svelte';
-import type { AppClient, Record, EntryHash, AgentPubKey, ActionHash, DnaHash, HolochainError } from '@holochain/client';
-import { type ClientContext, clientContext } from '../../contexts';
+import { createEventDispatcher, onMount } from 'svelte';
+import type { Record, EntryHash, AgentPubKey, ActionHash, DnaHash, HolochainError } from '@holochain/client';
+import { getClient } from '../../contexts';
 import type { {{pascal_case entry_type.name}}{{#each entry_type.fields}}{{#if (eq field_type.type "Enum")}}, {{field_type.label}}{{/if}}{{/each}} } from './types';
 {{#uniq_lines}}
   {{#each entry_type.fields}}
     {{#if widget}}
 {{> (concat field_type.type "/" widget "/edit/imports") }}
-
     {{/if}}
   {{/each}}
 {{/uniq_lines}}
 
 const dispatch = createEventDispatcher();
-let client: AppClient;
-const appClientContext = getContext<ClientContext>(clientContext);
+const clientStore = getClient();
 
 {{#each entry_type.fields}}
   {{#if widget }}
@@ -22,7 +20,7 @@ const appClientContext = getContext<ClientContext>(clientContext);
 let {{camel_case field_name}}: {{> (concat field_type.type "/type") }}{{#if (eq cardinality "option")}} | undefined{{/if}} = {{> (concat field_type.type "/" widget "/initial-value") field_type=field_type}};
     {{else}}
       {{#if (eq field_type.type "u8")}}
-let {{camel_case field_name}}: Uint8Array = [{{> (concat field_type.type "/" widget "/initial-value") field_type=field_type}}];
+let {{camel_case field_name}}: Uint8Array = new Uint8Array([{{> (concat field_type.type "/" widget "/initial-value") field_type=field_type}}]);
       {{else}}
 let {{camel_case field_name}}: Array<{{> (concat field_type.type "/type")}}> = [{{> (concat field_type.type "/" widget "/initial-value") field_type=field_type}}];
       {{/if}}
@@ -34,12 +32,12 @@ let {{camel_case field_name}}: Array<{{> (concat field_type.type "/type")}}> = [
   {{#if (not widget) }}
     {{#if (eq cardinality "vector")}}
       {{#if (eq field_type.type "u8")}}
-export let {{camel_case field_name}}!: Uint8Array;
+export let {{camel_case field_name}}: Uint8Array;
       {{else}}
-export let {{camel_case field_name}}!: Array<{{> (concat field_type.type "/type") }}>;
+export let {{camel_case field_name}}: Array<{{> (concat field_type.type "/type") }}>;
       {{/if}}
     {{else}}
-export let {{camel_case field_name}}{{#if (eq cardinality "single")}}!{{/if}}: {{> (concat field_type.type "/type") }}{{#if (eq cardinality "option")}} | undefined{{/if}};
+export let {{camel_case field_name}}{{#if (eq cardinality "single")}}{{/if}}: {{> (concat field_type.type "/type") }}{{#if (eq cardinality "option")}} | undefined{{/if}};
     {{/if}}
   {{/if}}
 {{/each}}
@@ -47,39 +45,42 @@ export let {{camel_case field_name}}{{#if (eq cardinality "single")}}!{{/if}}: {
 $: {{#each entry_type.fields}}{{camel_case field_name}}{{#unless @last}}, {{/unless}}{{/each}};
 $: is{{pascal_case entry_type.name}}Valid = true{{#each entry_type.fields}}{{#if widget}}{{#if (eq cardinality "single")}} && {{> (concat field_type.type "/" widget "/is-valid") variable_to_validate=(camel_case field_name) }}{{/if}}{{#if (eq cardinality "vector")}} && {{camel_case field_name}}.every(e => {{> (concat field_type.type "/" widget "/is-valid") variable_to_validate="e" }}){{/if}}{{/if}}{{/each}};
 
-onMount(async () => {
-{{#each entry_type.fields}}
-  {{#if (not widget) }}
-    {{#if (ne cardinality "option")}}
+onMount(() => {
+  {{#each entry_type.fields}}
+    {{#if (not widget) }}
+      {{#if (ne cardinality "option")}}
   if ({{camel_case field_name}} === undefined) {
     throw new Error(`The {{camel_case field_name}} input is required for the Create{{pascal_case ../entry_type.name}} element`);
   }
+      {{/if}}
     {{/if}}
-  {{/if}}
-{{/each}}
-  client = await appClientContext.getClient();
+  {{/each}}
 });
 
 async function create{{pascal_case entry_type.name}}() {
+  if (!$clientStore.client) return;
+
   const {{camel_case entry_type.name}}Entry: {{pascal_case entry_type.name}} = {
-  {{#each entry_type.fields}}
+    {{#each entry_type.fields}}
     {{snake_case field_name}}: {{camel_case field_name}}{{#if (eq cardinality "single")}}!{{/if}},
-  {{/each}}
+    {{/each}}
   };
 
   try {
-    const record: Record = await client.callZome({
+    const record: Record = await $clientStore.client.callZome({
       role_name: '{{dna_role_name}}',
       zome_name: '{{coordinator_zome_manifest.name}}',
       fn_name: 'create_{{snake_case entry_type.name}}',
       payload: {{camel_case entry_type.name}}Entry,
     });
-    dispatch('{{kebab_case entry_type.name}}-created', { {{camel_case entry_type.name}}Hash: record.signed_action.hashed.hash });
+    
+    dispatch('{{kebab_case entry_type.name}}-created', { 
+      {{camel_case entry_type.name}}Hash: record.signed_action.hashed.hash 
+    });
   } catch (e) {
-    alert((e as HolochainError).message)
+    alert((e as HolochainError).message);
   }
 }
-
 </script>
 
 <div>

--- a/templates/ui-frameworks/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.svelte{{¡if}}{{¡each}}.hbs
+++ b/templates/ui-frameworks/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#each entry_type.fields}}{{#if (and linked_from (not (eq linked_from.hash_type 'AgentPubKey') ) )}}{{pascal_case (plural ..¡entry_type.name)}}For{{pascal_case linked_from.name}}.svelte{{¡if}}{{¡each}}.hbs
@@ -1,64 +1,57 @@
 <script lang="ts">
-import { onMount, getContext } from 'svelte';
-import type {
-  Link,
-  ActionHash,
-  EntryHash,
-  AppClient,
-  Record,
-  AgentPubKey,
-  NewEntryAction,
-  HolochainError,
-  SignalType,
-} from '@holochain/client';
+import { onMount } from 'svelte';
+import type { Link, ActionHash, EntryHash, Record, AgentPubKey, NewEntryAction, HolochainError } from '@holochain/client';
 import { SignalType } from '@holochain/client';
-import { type ClientContext, clientContext } from '../../contexts';
+import { getClient } from '../../contexts';
 import type { {{pascal_case ../entry_type.name}}, {{pascal_case ../coordinator_zome_manifest.name}}Signal } from './types';
 import {{pascal_case ../entry_type.name}}Detail from './{{pascal_case ../entry_type.name}}Detail.svelte';
 
-let client: AppClient;
-const appClientContext = getContext<ClientContext>(clientContext);
-
-let hashes: Array<ActionHash> | undefined = [];
-let loading: boolean;
-let error: any = undefined;
-
 export let {{camel_case linked_from.singular_arg}}: {{linked_from.hash_type}};
 
-$: hashes, loading, error;
+const clientStore = getClient();
 
-onMount(async () => {
-  if ({{camel_case linked_from.singular_arg}} === undefined) {
-    throw new Error(`The {{camel_case linked_from.singular_arg}} input is required for the {{pascal_case (plural ../entry_type.name)}}For{{pascal_case linked_from.name}} element`);
-  }
-  client = await appClientContext.getClient();
-  await fetch{{pascal_case (plural ../entry_type.name)}}();
-
-  client.on('signal', async signal => {
-    if (!(SignalType.App in signal)) return;
-    if (signal.App.zome_name !== '{{../coordinator_zome_manifest.name}}') return;
-    const payload = signal.App.payload as {{pascal_case ../coordinator_zome_manifest.name}}Signal;
-    if (!(payload.type === 'EntryCreated' && payload.app_entry.type === '{{pascal_case ../entry_type.name}}')) return;
-    await fetch{{pascal_case (plural ../entry_type.name)}}();
-  });
-});
+let hashes: Array<ActionHash> = [];
+let loading = false;
+let error: HolochainError | undefined = undefined;
 
 async function fetch{{pascal_case (plural ../entry_type.name)}}() {
   loading = true;
   try {
-    const links: Array<Link> = await client.callZome({
+    const links: Array<Link> = await $clientStore.client?.callZome({
       role_name: '{{../dna_role_name}}',
       zome_name: '{{../coordinator_zome_manifest.name}}',
       fn_name: 'get_{{snake_case (plural ../entry_type.name)}}_for_{{snake_case linked_from.name}}',
       payload: {{camel_case linked_from.singular_arg}}
     });
-    hashes = links.map(l => l.target);
+    hashes = links?.map(l => l.target) || [];
   } catch (e) {
     error = e as HolochainError;
   } finally {
     loading = false;
   }
 }
+
+function handleSignal(signal: any) {
+  if (!(SignalType.App in signal)) return;
+  if (signal.App.zome_name !== '{{../coordinator_zome_manifest.name}}') return;
+  const payload = signal.App.payload as {{pascal_case ../coordinator_zome_manifest.name}}Signal;
+  if (!(payload.type === 'EntryCreated' && payload.app_entry.type === '{{pascal_case ../entry_type.name}}')) return;
+
+  fetch{{pascal_case (plural ../entry_type.name)}}();
+}
+
+onMount(async () => {
+  if ({{camel_case linked_from.singular_arg}} === undefined) {
+    throw new Error(
+      `The {{camel_case linked_from.singular_arg}} input is required for the {{pascal_case (plural ../entry_type.name)}}For{{pascal_case linked_from.name}} element`
+    );
+  }
+
+  if ($clientStore.client) {
+    await fetch{{pascal_case (plural ../entry_type.name)}}();
+    $clientStore.client.on('signal', handleSignal);
+  }
+});
 </script>
 
 {#if loading }

--- a/templates/ui-frameworks/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if crud.update}}Edit{{pascal_case entry_type.name}}.svelte{{¡if}}.hbs
+++ b/templates/ui-frameworks/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if crud.update}}Edit{{pascal_case entry_type.name}}.svelte{{¡if}}.hbs
@@ -1,35 +1,34 @@
 <script lang="ts">
-import { createEventDispatcher, getContext, onMount } from 'svelte';
-import type { AppClient, Record, EntryHash, AgentPubKey, DnaHash, ActionHash, HolochainError } from '@holochain/client';
+import { createEventDispatcher, onMount } from 'svelte';
+import type { Record, EntryHash, AgentPubKey, DnaHash, ActionHash, HolochainError } from '@holochain/client';
 import { decode } from '@msgpack/msgpack';
-import { type ClientContext, clientContext } from '../../contexts';
+import { getClient } from '../../contexts';
 import type { {{pascal_case entry_type.name}}{{#each entry_type.fields}}{{#if (eq field_type.type "Enum")}}, {{field_type.label}}{{/if}}{{/each}} } from './types';
 {{#uniq_lines}}
   {{#each entry_type.fields}}
     {{#if widget}}
 {{> (concat field_type.type "/" widget "/edit/imports") }}
-
     {{/if}}
   {{/each}}
 {{/uniq_lines}}
 
-let client: AppClient;
-const appClientContext = getContext<ClientContext>(clientContext);
 const dispatch = createEventDispatcher();
+const clientStore = getClient();
 
-export let currentRecord!: Record;
+export let currentRecord: Record;
 {{#if link_from_original_to_each_update}}
-export let original{{pascal_case entry_type.name}}Hash!: ActionHash;
+export let original{{pascal_case entry_type.name}}Hash: ActionHash;
 {{/if}}
 
 let current{{pascal_case entry_type.name}}: {{pascal_case entry_type.name}} = decode((currentRecord.entry as any).Present.entry) as {{pascal_case entry_type.name}};
+
 {{#each entry_type.fields}}
   {{#if widget }}
     {{#if (not (eq cardinality "vector" ) )}}
 let {{camel_case field_name}}: {{> (concat field_type.type "/type")}} | undefined = current{{pascal_case ../entry_type.name}}.{{snake_case field_name}};
     {{else}}
       {{#if (eq field_type.type "u8")}}
-let {{camel_case field_name}}: Uint8Array | undefined> = current{{pascal_case ../entry_type.name}}.{{snake_case field_name}};
+let {{camel_case field_name}}: Uint8Array | undefined = current{{pascal_case ../entry_type.name}}.{{snake_case field_name}};
       {{else}}
 let {{camel_case field_name}}: Array<{{> (concat field_type.type "/type")}} | undefined> = current{{pascal_case ../entry_type.name}}.{{snake_case field_name}};
       {{/if}}
@@ -40,38 +39,39 @@ let {{camel_case field_name}}: Array<{{> (concat field_type.type "/type")}} | un
 $: {{#each (filter entry_type.fields "widget")}}{{camel_case field_name}}{{#unless @last}}, {{/unless}}{{/each}};
 $: is{{pascal_case entry_type.name}}Valid = true{{#each entry_type.fields}}{{#if widget}}{{#if (eq cardinality "single")}} && {{> (concat field_type.type "/" widget "/is-valid") variable_to_validate=(camel_case field_name) }}{{/if}}{{#if (eq cardinality "vector")}} && {{camel_case field_name}}.every(e => {{> (concat field_type.type "/" widget "/is-valid") variable_to_validate="e" }}){{/if}}{{/if}}{{/each}};
 
-onMount(async () => {
+onMount(() => {
   if (!currentRecord) {
     throw new Error(`The currentRecord input is required for the Edit{{pascal_case entry_type.name}} element`);
   }
-{{#if link_from_original_to_each_update}}
+  {{#if link_from_original_to_each_update}}
   if (!original{{pascal_case entry_type.name}}Hash) {
     throw new Error(`The original{{pascal_case entry_type.name}}Hash input is required for the Edit{{pascal_case entry_type.name}} element`);
   }
-{{/if}}
-client = await appClientContext.getClient();
+  {{/if}}
 });
 
 async function update{{pascal_case entry_type.name}}() {
+  if (!$clientStore.client) return;
+
   const {{camel_case entry_type.name}}: {{pascal_case entry_type.name}} = {
-  {{#each entry_type.fields}}
-    {{#if widget}}
-      {{#if (eq cardinality "single") }}
+    {{#each entry_type.fields}}
+      {{#if widget}}
+        {{#if (eq cardinality "single") }}
     {{snake_case field_name}}: {{camel_case field_name}}!,
-      {{else}}
+        {{else}}
     {{snake_case field_name}}: {{camel_case field_name}}{{#if (eq cardinality "vector") }} as Array<{{> (concat field_type.type "/type") }}>{{/if}},
+        {{/if}}
       {{/if}}
-    {{/if}}
-  {{/each}}
-  {{#each entry_type.fields}}
-    {{#if (not widget)}}
+    {{/each}}
+    {{#each entry_type.fields}}
+      {{#if (not widget)}}
     {{snake_case field_name}}: current{{pascal_case ../entry_type.name}}.{{snake_case field_name}},
-    {{/if}}
-  {{/each}}
+      {{/if}}
+    {{/each}}
   };
 
   try {
-    const updateRecord: Record = await client.callZome({
+    const updateRecord: Record = await $clientStore.client.callZome({
       role_name: '{{dna_role_name}}',
       zome_name: '{{coordinator_zome_manifest.name}}',
       fn_name: 'update_{{snake_case entry_type.name}}',
@@ -84,9 +84,11 @@ async function update{{pascal_case entry_type.name}}() {
       }
     });
 
-    dispatch('{{kebab_case entry_type.name}}-updated', { actionHash: updateRecord.signed_action.hashed.hash });
+    dispatch('{{kebab_case entry_type.name}}-updated', {
+      actionHash: updateRecord.signed_action.hashed.hash
+    });
   } catch (e) {
-    alert((e as HolochainError).message)
+    alert((e as HolochainError).message);
   }
 }
 </script>

--- a/templates/ui-frameworks/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case entry_type.name}}Detail.svelte.hbs
+++ b/templates/ui-frameworks/svelte/entry-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{pascal_case entry_type.name}}Detail.svelte.hbs
@@ -1,8 +1,8 @@
 <script lang="ts">
-import { createEventDispatcher, onMount, getContext } from 'svelte';
+import { createEventDispatcher, onMount } from 'svelte';
 import { decode } from '@msgpack/msgpack';
-import type { Record, ActionHash, AppClient, EntryHash, AgentPubKey, DnaHash, HolochainError } from '@holochain/client';
-import { type ClientContext, clientContext } from '../../contexts';
+import type { Record, ActionHash, EntryHash, AgentPubKey, DnaHash, HolochainError } from '@holochain/client';
+import { getClient } from "../../contexts";
 import type { {{pascal_case entry_type.name}}{{#each entry_type.fields}}{{#if (eq field_type.type "Enum")}}, {{field_type.label}}{{/if}}{{/each}} } from './types';
 {{#if crud.update}}
 import Edit{{pascal_case entry_type.name}} from './Edit{{pascal_case entry_type.name}}.svelte';
@@ -11,16 +11,16 @@ import Edit{{pascal_case entry_type.name}} from './Edit{{pascal_case entry_type.
   {{#each entry_type.fields}}
     {{#if widget}}
 {{> (concat field_type.type "/" widget "/detail/imports") }}
-
     {{/if}}
   {{/each}}
 {{/uniq_lines}}
 
-let client: AppClient;
-const appClientContext = getContext<ClientContext>(clientContext);
 const dispatch = createEventDispatcher();
+const clientStore = getClient();
 
-let loading: boolean = false;
+export let {{camel_case entry_type.name}}Hash: {{#if entry_type.reference_entry_hash}}EntryHash{{else}}ActionHash{{/if}};
+
+let loading = false;
 {{#if crud.update}}
 let editing = false;
 {{/if}}
@@ -28,27 +28,18 @@ let error: HolochainError | undefined;
 let record: Record | undefined;
 let {{camel_case entry_type.name}}: {{pascal_case entry_type.name}} | undefined;
 
-export let {{camel_case entry_type.name}}Hash: {{#if entry_type.reference_entry_hash}}EntryHash{{else}}ActionHash{{/if}};
-
-$: {{#if crud.update}}editing,{{/if}} error, loading, record, {{camel_case entry_type.name}};
-
-onMount(async () => {
-  if ({{camel_case entry_type.name}}Hash === undefined) {
-    throw new Error(`The {{camel_case entry_type.name}}Hash input is required for the {{pascal_case entry_type.name}}Detail element`);
-  }
-  client = await appClientContext.getClient();
-  await fetch{{pascal_case entry_type.name}}();
-});
-
 async function fetch{{pascal_case entry_type.name}}() {
+  if (!$clientStore.client) return;
+  
   loading = true;
   try {
-    record = await client.callZome({
+    record = await $clientStore.client.callZome({
       role_name: '{{dna_role_name}}',
       zome_name: '{{coordinator_zome_manifest.name}}',
       fn_name: '{{#if crud.update}}get_latest_{{snake_case entry_type.name}}{{else}}get_{{snake_case entry_type.name}}{{/if}}',
       payload: {{camel_case entry_type.name}}Hash,
     });
+    
     if (record) {
       {{camel_case entry_type.name}} = decode((record.entry as any).Present.entry) as {{pascal_case entry_type.name}};
     }
@@ -61,19 +52,36 @@ async function fetch{{pascal_case entry_type.name}}() {
 
 {{#if crud.delete}}
 async function delete{{pascal_case entry_type.name}}() {
+  if (!$clientStore.client) return;
+
   try {
-    await client.callZome({
+    await $clientStore.client.callZome({
       role_name: '{{dna_role_name}}',
       zome_name: '{{coordinator_zome_manifest.name}}',
       fn_name: 'delete_{{snake_case entry_type.name}}',
       payload: {{camel_case entry_type.name}}Hash,
     });
-    dispatch('{{kebab_case entry_type.name}}-deleted', { {{camel_case entry_type.name}}Hash: {{camel_case entry_type.name}}Hash });
+    
+    dispatch('{{kebab_case entry_type.name}}-deleted', { 
+      {{camel_case entry_type.name}}Hash 
+    });
   } catch (e) {
-    alert((e as HolochainError).message)
+    alert((e as HolochainError).message);
   }
 }
 {{/if}}
+
+onMount(async () => {
+  if ({{camel_case entry_type.name}}Hash === undefined) {
+    throw new Error(
+      `The {{camel_case entry_type.name}}Hash input is required for the {{pascal_case entry_type.name}}Detail element`
+    );
+  }
+
+  if ($clientStore.client) {
+    await fetch{{pascal_case entry_type.name}}();
+  }
+});
 </script>
 
 {#if loading}

--- a/templates/ui-frameworks/svelte/example/ui/src/App.svelte.hbs
+++ b/templates/ui-frameworks/svelte/example/ui/src/App.svelte.hbs
@@ -4,25 +4,20 @@ import CreatePost from "./forum/posts/CreatePost.svelte";
 import { onMount } from "svelte";
 import { createClientStore, CLIENT_CONTEXT_KEY } from './contexts';
 import { setContext } from 'svelte';
+import ClientProvider from './ClientProvider.svelte';
 
 const clientStore = createClientStore();
 setContext(CLIENT_CONTEXT_KEY, clientStore);
-
-$: ({ loading } = $clientStore);
 
 onMount(() => {
   clientStore.connect();
 });
 </script>
 
-<main>
-  {#if loading}
-    <progress />
-  {:else}
-    <div>
-      <h2>Welcome to the Forum hApp</h2>
-      <AllPosts />
-      <CreatePost />
-    </div>
-  {/if}
-</main>
+<ClientProvider>
+  <div>
+    <h2>Welcome to the Forum hApp</h2>
+    <AllPosts />
+    <CreatePost />
+  </div>
+</ClientProvider>

--- a/templates/ui-frameworks/svelte/example/ui/src/App.svelte.hbs
+++ b/templates/ui-frameworks/svelte/example/ui/src/App.svelte.hbs
@@ -1,36 +1,18 @@
 <script lang="ts">
-  import { onMount, setContext } from 'svelte';
-  import type { ActionHash, AppClient } from '@holochain/client';
-  import { AppWebsocket } from '@holochain/client';
-  import AllPosts from './forum/posts/AllPosts.svelte';
-  import CreatePost from './forum/posts/CreatePost.svelte';
+import AllPosts from "./forum/posts/AllPosts.svelte";
+import CreatePost from "./forum/posts/CreatePost.svelte";
+import { onMount } from "svelte";
+import { createClientStore, CLIENT_CONTEXT_KEY } from './contexts';
+import { setContext } from 'svelte';
 
-  import { type ClientContext, clientContext } from './contexts';
+const clientStore = createClientStore();
+setContext(CLIENT_CONTEXT_KEY, clientStore);
 
-  let client: AppClient | undefined;
-  let loading = false;
+$: ({ loading } = $clientStore);
 
-  const appClientContext = {
-    getClient: async () => {
-      if (!client) {
-        client = await AppWebsocket.connect();
-      }
-      return client;
-    },
-  };
-
-  onMount(async () => {
-    loading = true;
-    try {
-      client = await appClientContext.getClient();
-    } catch(e) {
-      console.error(e)
-    } finally {
-      loading = false;
-    }
-  });
-
-  setContext<ClientContext>(clientContext, appClientContext);
+onMount(() => {
+  clientStore.connect();
+});
 </script>
 
 <main>

--- a/templates/ui-frameworks/svelte/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{pascal_case (plural from_referenceable.name)}}For{{pascal_case to_referenceable.name}}.svelte{{¡if}}.hbs
+++ b/templates/ui-frameworks/svelte/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and bidireccional (and to_referenceable (ne from_referenceable.hash_type 'AgentPubKey')))}}{{pascal_case (plural from_referenceable.name)}}For{{pascal_case to_referenceable.name}}.svelte{{¡if}}.hbs
@@ -1,40 +1,36 @@
 <script lang="ts">
-import { onMount, getContext } from 'svelte';
-import type {
-  Link,
-  Record,
-  ActionHash,
-  EntryHash,
-  AgentPubKey,
-  AppClient,
-  NewEntryAction,
-  HolochainError,
-} from '@holochain/client';
+import { onMount } from 'svelte';
+import type { Link, Record, ActionHash, EntryHash, AgentPubKey, NewEntryAction, HolochainError } from '@holochain/client';
 import { SignalType } from '@holochain/client';
-import { type ClientContext, clientContext } from '../../contexts';
-import {{pascal_case from_referenceable.name}}Detail from './{{pascal_case from_referenceable.name}}Detail.svelte';
+import { getClient } from "../../contexts";
+from_referenceable.name}}Detail from './{{pascal_case from_referenceable.name}}Detail.svelte';
 import type { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
-
-let client: AppClient;
-const appClientContext = getContext<ClientContext>(clientContext);
-
-let hashes: Array<{{from_referenceable.hash_type}}> | undefined;
-let loading = false;
-let error: any = undefined;
 
 export let {{camel_case to_referenceable.singular_arg}}: {{to_referenceable.hash_type}};
 
-$: hashes, loading, error;
+const clientStore = getClient();
 
-onMount(async () => {
-  if (!{{camel_case to_referenceable.singular_arg}}) {
-    throw new Error(`The {{camel_case to_referenceable.singular_arg}} input is required for the {{pascal_case (plural from_referenceable.name)}}For{{pascal_case to_referenceable.name}} element`);
-  }
+let hashes: Array<{{from_referenceable.hash_type}}> = [];
+let loading = false;
+let error: HolochainError | undefined = undefined;
 
+function handleSignal(signal: any) {
+  if (!(SignalType.App in signal)) return;
+  if (signal.App.zome_name !== '{{coordinator_zome_manifest.name}}') return;
+
+  const payload = signal.App.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
+  if (payload.type !== 'LinkCreated') return;
+  if (payload.link_type !== '{{pascal_case bidirectional}}') return;
+
+  hashes = [...hashes, payload.action.hashed.content.target_address];
+}
+
+async function fetchLinks() {
+  if (!$clientStore.client) return;
+
+  loading = true;
   try {
-    loading = true;
-    client = await appClientContext.getClient();
-    const links: Array<Link> = await client.callZome({
+    const links: Array<Link> = await $clientStore.client.callZome({
       role_name: '{{dna_role_name}}',
       zome_name: '{{snake_case coordinator_zome_manifest.name}}',
       fn_name: 'get_{{snake_case (plural from_referenceable.name)}}_for_{{snake_case to_referenceable.name}}',
@@ -46,16 +42,19 @@ onMount(async () => {
   } finally {
     loading = false;
   }
+}
 
-  client.on('signal', signal => {
-    if (!(SignalType.App in signal)) return;
-    if (signal.App.zome_name !== '{{coordinator_zome_manifest.name}}') return;
-    const payload = signal.App.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
-    if (payload.type !== 'LinkCreated') return;
-    if (payload.link_type !== '{{pascal_case bidirectional}}') return;
+onMount(async () => {
+  if (!{{camel_case to_referenceable.singular_arg}}) {
+    throw new Error(
+      `The {{camel_case to_referenceable.singular_arg}} input is required for the {{pascal_case (plural from_referenceable.name)}}For{{pascal_case to_referenceable.name}} element`
+    );
+  }
 
-    hashes = [...hashes, payload.action.hashed.content.target_address];
-  });
+  if ($clientStore.client) {
+    await fetchLinks();
+    $clientStore.client.on('signal', handleSignal);
+  }
 });
 </script>
 

--- a/templates/ui-frameworks/svelte/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and to_referenceable (ne to_referenceable.hash_type 'AgentPubKey'))}}{{pascal_case (plural to_referenceable.name)}}For{{pascal_case from_referenceable.name}}.svelte{{¡if}}.hbs
+++ b/templates/ui-frameworks/svelte/link-type/ui/src/{{dna_role_name}}/{{coordinator_zome_manifest.name}}/{{#if (and to_referenceable (ne to_referenceable.hash_type 'AgentPubKey'))}}{{pascal_case (plural to_referenceable.name)}}For{{pascal_case from_referenceable.name}}.svelte{{¡if}}.hbs
@@ -1,60 +1,58 @@
 <script lang="ts">
-import { onMount, getContext } from 'svelte';
-import type {
-  Link,
-  Record,
-  EntryHash,
-  ActionHash,
-  AgentPubKey,
-  AppClient,
-  NewEntryAction,
-  HolochainError,
-} from '@holochain/client';
+import { onMount } from 'svelte';
+import type { Link, Record, EntryHash, ActionHash, AgentPubKey, NewEntryAction, HolochainError } from '@holochain/client';
 import { SignalType } from '@holochain/client';
-import { type ClientContext, clientContext } from '../../contexts';
+import { getClient } from "../../contexts";
 import {{pascal_case to_referenceable.name}}Detail from './{{pascal_case to_referenceable.name}}Detail.svelte';
 import type { {{pascal_case coordinator_zome_manifest.name}}Signal } from './types';
 
-let client: AppClient;
-const appClientContext = getContext<ClientContext>(clientContext);
-
-let hashes: Array<{{to_referenceable.hash_type}}> | undefined;
-let loading = false;
-let error: any = undefined;
-
 export let {{camel_case from_referenceable.singular_arg}}: {{from_referenceable.hash_type}};
 
-$: hashes, loading, error;
+const clientStore = getClient();
 
-onMount(async () => {
-  if (!{{camel_case from_referenceable.singular_arg}}) {
-    throw new Error(`The {{camel_case from_referenceable.singular_arg}} input is required for the {{pascal_case (plural to_referenceable.name)}}For{{pascal_case from_referenceable.name}} element`);
-  }
-  client = await appClientContext.getClient();
+let hashes: Array<{{to_referenceable.hash_type}}> = [];
+let loading = false;
+let error: HolochainError | undefined = undefined;
+
+function handleSignal(signal: any) {
+  if (!(SignalType.App in signal)) return;
+  if (signal.App.zome_name !== '{{coordinator_zome_manifest.name}}') return;
+
+  const payload = signal.App.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
+  if (payload.type !== 'LinkCreated') return;
+  if (payload.link_type !== '{{pascal_case link_type_name}}') return;
+
+  hashes = [...hashes, payload.action.hashed.content.target_address];
+}
+
+async function fetchLinks() {
+  loading = true;
   try {
-    loading = true;
-    const links: Array<Link> = await client.callZome({
+    const links: Array<Link> = await $clientStore.client?.callZome({
       role_name: '{{dna_role_name}}',
       zome_name: '{{coordinator_zome_manifest.name}}',
       fn_name: 'get_{{snake_case (plural to_referenceable.name)}}_for_{{snake_case from_referenceable.name}}',
       payload: {{camel_case from_referenceable.singular_arg}},
     });
-    hashes = links.map(l => l.target);
+    hashes = links?.map(l => l.target) || [];
   } catch (e) {
     error = e as HolochainError;
   } finally {
     loading = false;
   }
+}
 
-  client.on('signal', signal => {
-    if (!(SignalType.App in signal)) return;
-    if (signal.App.zome_name !== '{{coordinator_zome_manifest.name}}') return;
-    const payload = signal.App.payload as {{pascal_case coordinator_zome_manifest.name}}Signal;
-    if (payload.type !== 'LinkCreated') return;
-    if (payload.link_type !== '{{pascal_case link_type_name}}') return;
+onMount(async () => {
+  if (!{{camel_case from_referenceable.singular_arg}}) {
+    throw new Error(
+      `The {{camel_case from_referenceable.singular_arg}} input is required for the {{pascal_case (plural to_referenceable.name)}}For{{pascal_case from_referenceable.name}} element`
+    );
+  }
 
-    hashes = [...hashes, payload.action.hashed.content.target_address];
-  });
+  if ($clientStore.client) {
+    await fetchLinks();
+    $clientStore.client.on('signal', handleSignal);
+  }
 });
 </script>
 

--- a/templates/ui-frameworks/svelte/web-app/ui/src/App.svelte.hbs
+++ b/templates/ui-frameworks/svelte/web-app/ui/src/App.svelte.hbs
@@ -2,7 +2,7 @@
 import { onMount } from 'svelte';
 import { setContext } from 'svelte';
 import logo from './assets/holochainLogo.svg';
-import { CLIENT_CONTEXT_KEY, createClientStore } from './contexts';
+import ClientProvider from './ClientProvider.svelte';
 
 const clientStore = createClientStore();
 setContext(CLIENT_CONTEXT_KEY, clientStore);
@@ -14,7 +14,7 @@ onMount(() => {
 });
 </script>
 
-<main>
+<ClientProvider>
   <div>
     <a href="https://developer.holochain.org/get-started/" target="_blank">
       <img src={logo} class="logo holochain" alt="holochain logo" />
@@ -34,7 +34,7 @@ onMount(() => {
     <p>Import scaffolded components into <code>src/App.svelte</code> to use your hApp</p>
     <p class="read-the-docs">Click on the Holochain logo to learn more</p>
   </div>
-</main>
+</ClientProvider>
 
 <style>
   .logo {

--- a/templates/ui-frameworks/svelte/web-app/ui/src/App.svelte.hbs
+++ b/templates/ui-frameworks/svelte/web-app/ui/src/App.svelte.hbs
@@ -1,72 +1,17 @@
 <script lang="ts">
-  import { onMount, setContext } from 'svelte';
-  import type { ActionHash, AppClient, HolochainError } from '@holochain/client';
-  import { AppWebsocket } from '@holochain/client';
-{{#if holo_enabled}}
-  import WebSdk from '@holo-host/web-sdk'
-{{/if}}
+import { onMount } from 'svelte';
+import { setContext } from 'svelte';
+import logo from './assets/holochainLogo.svg';
+import { CLIENT_CONTEXT_KEY, createClientStore } from './contexts';
 
-  import logo from './assets/holochainLogo.svg';
-  import { type ClientContext, clientContext } from './contexts';
+const clientStore = createClientStore();
+setContext(CLIENT_CONTEXT_KEY, clientStore);
 
-{{#if holo_enabled}}
-  const IS_HOLO = ['true', '1', 't'].includes(import.meta.env.VITE_APP_IS_HOLO?.toLowerCase())
-  const logout = async () => {
-    await (client as WebSdk).signOut();
-    (client as WebSdk).signIn({ cancellable: false })
-  }
-{{/if}}
+$: ({ error, loading } = $clientStore);
 
-  let client: AppClient | undefined;
-  let error: HolochainError | undefined;
-  let loading = false;
-
-  const appClientContext = {
-    getClient: async () => {
-      if (!client) {
-        client = await AppWebsocket.connect();
-      }
-      return client;
-    },
-  };
-
-  onMount(async () => {
-  {{#if holo_enabled}}
-    try {
-      loading = true;
-      if (IS_HOLO) {
-        client = await WebSdk.connect({
-          chaperoneUrl: import.meta.env.VITE_APP_CHAPERONE_URL,
-          authFormCustomization: {
-            appName: '{{app_name}}',
-          }
-        });
-        (client as WebSdk).on('agent-state', agent_state => {
-          loading = !agent_state.isAvailable || agent_state.isAnonymous
-        });
-        (client as WebSdk).signUp({ cancellable: false });
-      } else {
-        client = await appClientContext.getClient();
-        loading = false;
-      }
-    } catch (e) {
-      error = e as HolochainError;
-    } finally {
-      loading = false;
-    }
-  {{else}}
-    try {
-      loading = true;
-      client = await appClientContext.getClient();
-    } catch (e) {
-      error = e as HolochainError;
-    } finally {
-      loading = false;
-    }
-  {{/if}}
-  });
-
-  setContext<ClientContext>(clientContext, appClientContext);
+onMount(() => {
+  clientStore.connect();
+});
 </script>
 
 <main>

--- a/templates/ui-frameworks/svelte/web-app/ui/src/ClientProvider.svelte.hbs
+++ b/templates/ui-frameworks/svelte/web-app/ui/src/ClientProvider.svelte.hbs
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { onMount, setContext } from 'svelte';
+  import { CLIENT_CONTEXT_KEY, createClientStore } from './contexts';
+
+  const clientStore = createClientStore();
+  setContext(CLIENT_CONTEXT_KEY, clientStore);
+
+  onMount(() => {
+    clientStore.connect();
+  });
+
+  $: ({ client, error, loading } = $clientStore);
+</script>
+
+{#if loading}
+  <progress></progress>
+{:else if error}
+  <div class="alert">
+    Error connecting to Holochain: {error.message}
+  </div>
+{:else if client}
+  <slot />
+{/if}

--- a/templates/ui-frameworks/svelte/web-app/ui/src/contexts.ts.hbs
+++ b/templates/ui-frameworks/svelte/web-app/ui/src/contexts.ts.hbs
@@ -1,7 +1,83 @@
-import { type AppClient } from "@holochain/client";
+import { writable, type Writable } from 'svelte/store';
+import { getContext, setContext } from 'svelte';
+import type { AppClient, HolochainError } from '@holochain/client';
+import { AppWebsocket } from '@holochain/client';
+{{#if holo_enabled}}
+import WebSdk from '@holo-host/web-sdk';
+{{/if}}
 
-export const clientContext = "AppClient";
+export const CLIENT_CONTEXT_KEY = Symbol('holochain-client');
 
-export type ClientContext = {
-  getClient: () => Promise<AppClient>;
-};
+interface ClientStore {
+  client: AppClient | undefined;
+  error: HolochainError | undefined;
+  loading: boolean;
+}
+
+{{#if holo_enabled}}
+const IS_HOLO = ['true', '1', 't'].includes(import.meta.env.VITE_APP_IS_HOLO?.toLowerCase());
+{{/if}}
+
+export function createClientStore() {
+  const store = writable<ClientStore>({
+    client: undefined,
+    error: undefined,
+    loading: false
+  });
+
+  const { subscribe, set, update } = store;
+
+  return {
+    subscribe,
+    connect: async () => {
+      update(s => ({ ...s, loading: true }));
+      try {
+        {{#if holo_enabled}}
+        if (IS_HOLO) {
+          const client = await WebSdk.connect({
+            chaperoneUrl: import.meta.env.VITE_APP_CHAPERONE_URL,
+            authFormCustomization: {
+              appName: '{{app_name}}',
+            }
+          });
+          
+          (client as WebSdk).on('agent-state', agent_state => {
+            update(s => ({ ...s, loading: !agent_state.isAvailable || agent_state.isAnonymous }));
+          });
+          
+          (client as WebSdk).signUp({ cancellable: false });
+          update(s => ({ ...s, client }));
+        } else {
+          const client = await AppWebsocket.connect();
+          update(s => ({ ...s, client }));
+        }
+        {{else}}
+        const client = await AppWebsocket.connect();
+        update(s => ({ ...s, client }));
+        {{/if}}
+      } catch (e) {
+        update(s => ({ ...s, error: e as HolochainError }));
+      } finally {
+        update(s => ({ ...s, loading: false }));
+      }
+    },
+    {{#if holo_enabled}}
+    logout: async () => {
+      const { client } = get(store);
+      if (client && IS_HOLO) {
+        await (client as WebSdk).signOut();
+        (client as WebSdk).signIn({ cancellable: false });
+      }
+    },
+    {{/if}}
+    getClient: () => {
+      const { client } = get(store);
+      if (!client) throw new Error('Client not initialized');
+      return client;
+    }
+  };
+}
+
+export function getClient() {
+  return getContext<ReturnType<typeof createClientStore>>(CLIENT_CONTEXT_KEY);
+}

--- a/templates/ui-frameworks/svelte/web-app/ui/src/contexts.ts.hbs
+++ b/templates/ui-frameworks/svelte/web-app/ui/src/contexts.ts.hbs
@@ -1,5 +1,5 @@
-import { writable, type Writable } from 'svelte/store';
-import { getContext, setContext } from 'svelte';
+import { writable, get } from 'svelte/store';
+import { getContext } from 'svelte';
 import type { AppClient, HolochainError } from '@holochain/client';
 import { AppWebsocket } from '@holochain/client';
 {{#if holo_enabled}}
@@ -56,6 +56,7 @@ export function createClientStore() {
         update(s => ({ ...s, client }));
         {{/if}}
       } catch (e) {
+        console.error(e);
         update(s => ({ ...s, error: e as HolochainError }));
       } finally {
         update(s => ({ ...s, loading: false }));


### PR DESCRIPTION
Closes #466 

This PR adds measures to ensure the client is not accessible before its initialized. This is achieved by moving the client state to a global state and and sharing it across child components.

**Blocked by failing CI**