### PR TITLE
bump hc-spin to 0.500.0-dev.1

### DIFF
--- a/src/versions.rs
+++ b/src/versions.rs
@@ -5,7 +5,7 @@ pub const TRYORAMA_VERSION: &str = "^0.18.0-dev.5";
 pub const HOLOCHAIN_CLIENT_VERSION: &str = "^0.19.0-dev.7";
 
 /// npm: <https://www.npmjs.com/package/@holochain/hc-spin>
-pub const HC_SPIN_VERSION: &str = "^0.500.0-dev.0";
+pub const HC_SPIN_VERSION: &str = "^0.500.0-dev.1";
 
 /// npm: <https://www.npmjs.com/package/@holo-host/web-sdk>
 pub const WEB_SDK_VERSION: &str = "^0.6.20-prerelease";


### PR DESCRIPTION
Bumps to `@holochain/hc-spin@0.500.0-dev.1` which is compatible with holochain 0.5.0-dev.21.