### PR TITLE
chore(ci): Disable fail-fast ci job strategy option

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,6 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [nix_build]
     strategy:
+      fail-fast: false
       matrix:
         template: [svelte, vue, lit, react, vanilla]
     steps:


### PR DESCRIPTION
Disabling to allow template tests to continue to run when one fails.