### PR TITLE
Bump vite-plugin-checker version

### DIFF
--- a/templates/ui-frameworks/lit/web-app/ui/package.json.hbs
+++ b/templates/ui-frameworks/lit/web-app/ui/package.json.hbs
@@ -28,7 +28,7 @@
     "tslib": "^2.8.0",
     "typescript": "^5.6.3",
     "vite": "^5.4.10",
-    "vite-plugin-checker": "^0.5.6"
+    "vite-plugin-checker": "^0.9.3"
   },
   "prettier": {
     "singleQuote": true,


### PR DESCRIPTION
Fixes a warning about the deprecated `lodash.pick` package.