### PR TITLE
Update nodejs version, update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1745454774,
-        "narHash": "sha256-oLvmxOnsEKGtwczxp/CwhrfmQUG2ym24OMWowcoRhH8=",
+        "lastModified": 1746291859,
+        "narHash": "sha256-DdWJLA+D5tcmrRSg5Y7tp/qWaD05ATI4Z7h22gd1h7Q=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "efd36682371678e2b6da3f108fdb5c613b3ec598",
+        "rev": "dfd9a8dfd09db9aad544c4d3b6c47b12562544a5",
         "type": "github"
       },
       "original": {
@@ -70,16 +70,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1745503820,
-        "narHash": "sha256-EmV7QpUrJq/8RJg63nah1MMpQ5fRZSBI8AioCNGb1M8=",
+        "lastModified": 1746718894,
+        "narHash": "sha256-b4WCqtHxz1F8wUAUoLS9dhJgkDf+Cey1B2VbpKO6+pQ=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "6878bd2a8cdd03954a6ee954d76c1c4675fd8af9",
+        "rev": "641de8152aaa6dc9fbec7a95ff65a3a52a5e2aa1",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.5.1",
+        "ref": "holochain-0.5.2",
         "repo": "holochain",
         "type": "github"
       }
@@ -100,16 +100,17 @@
         "nixpkgs": [
           "nixpkgs"
         ],
+        "playground": "playground",
         "rust-overlay": [
           "rust-overlay"
         ]
       },
       "locked": {
-        "lastModified": 1745528400,
-        "narHash": "sha256-ib7J80DCrkpHJURr6tzCFNvd1r1AGLmIcXRE2KgPlZ8=",
+        "lastModified": 1746737142,
+        "narHash": "sha256-YShUAquRKb3rEXlrI6o32Oa//z3GdzjxeqRzvi+lMBI=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "e58130a30f056d17c585e660dc5ee6ff9be19b73",
+        "rev": "1385ef067e0863e84143cd0453f4438550f069f8",
         "type": "github"
       },
       "original": {
@@ -122,16 +123,16 @@
     "kitsune2": {
       "flake": false,
       "locked": {
-        "lastModified": 1744924693,
-        "narHash": "sha256-d34dVCOXxTOR6bwLLIifD/lNAz90rmrjggUJ6uN+yV0=",
+        "lastModified": 1746114651,
+        "narHash": "sha256-+MCxcDBHNq0CH4fiLXdoXfj/NlvzMkCMEPyh2cXGrp8=",
         "owner": "holochain",
         "repo": "kitsune2",
-        "rev": "08ef58471ba0a4e3982ff13c5a41ce3cfbcadacd",
+        "rev": "203e2d333a4134d09ed63af7e8a6f00797e09168",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.1.5",
+        "ref": "v0.1.8",
         "repo": "kitsune2",
         "type": "github"
       }
@@ -184,6 +185,23 @@
         "type": "github"
       }
     },
+    "playground": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1745500757,
+        "narHash": "sha256-/Okvi/eg6aHHsbHyRpjNwMUuBNEudUbQ9lbt/Djbswc=",
+        "owner": "darksoil-studio",
+        "repo": "holochain-playground",
+        "rev": "9c5b509d24d2b38770a41b3c2bf8c2f280e8f20c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "darksoil-studio",
+        "ref": "main-0.5",
+        "repo": "holochain-playground",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "crane": "crane",
@@ -200,11 +218,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745548521,
-        "narHash": "sha256-xyliq8oS5OnzXjHRGr92RtmrtYI/dflf2gSEo0wMFjc=",
+        "lastModified": 1747017456,
+        "narHash": "sha256-C/U12fcO+HEF071b5mK65lt4XtAIZyJSSJAg9hdlvTk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "eb0afb4ac0720d55c29e88eb29432103d73ae11d",
+        "rev": "5b07506ae89b025b14de91f697eba23b48654c52",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
               hn-introspect
               rust
             ]) ++ (with pkgs; [
-              nodejs_20
+              nodejs_22
               binaryen
             ]) ++ [
               self'.packages.hc-scaffold

--- a/src/cli/custom-template/README.md
+++ b/src/cli/custom-template/README.md
@@ -41,7 +41,7 @@ nix run github:<TODO:REPLACE_ME_WITH_CUSTOM_TEMPLATE_GIT_URL>#app -- web-app
             devShells.default = pkgs.mkShell {
               inputsFrom = [ inputs'.holonix.devShells.default ];
               packages = [
-                pkgs.nodejs_20
+                pkgs.nodejs_22
                 # more packages go here
 +             ] ++ [
 +                inputs'.scaffolding.packages.app

--- a/src/cli/custom-template/flake.nix
+++ b/src/cli/custom-template/flake.nix
@@ -16,7 +16,7 @@
       devShells.default = pkgs.mkShell {
         inputsFrom = [ inputs'.holonix.devShells.default ];
 
-        packages = (with pkgs; [ nodejs_20 binaryen ]);
+        packages = (with pkgs; [ nodejs_22 binaryen ]);
 
         shellHook = ''
           export PS1='\[\033[1;34m\][holonix:\w]\$\[\033[0m\] '

--- a/src/scaffold/app/nix.rs
+++ b/src/scaffold/app/nix.rs
@@ -46,7 +46,7 @@ pub fn flake_nix(holo_enabled: bool, package_manager: &PackageManager) -> FileTr
         inputsFrom = [ inputs'.holonix.devShells.default ];
 
         packages = (with pkgs; [
-          nodejs_20
+          nodejs_22
           binaryen
           {}
           {}

--- a/src/scaffold/web_app/package_manager.rs
+++ b/src/scaffold/web_app/package_manager.rs
@@ -53,7 +53,7 @@ impl PackageManager {
             PackageManager::Bun => Some("bun"),
             PackageManager::Pnpm => Some("nodePackages.pnpm"),
             PackageManager::Yarn => Some("yarn"),
-            // npm is already included with nodejs_20
+            // npm is already included with nodejs_22
             PackageManager::Npm => None,
         }
     }


### PR DESCRIPTION
Updates the nodejs version which results in npm 10.9.2 and should therefore hopefully fix #495 (see https://github.com/npm/cli/issues/7891#issuecomment-2492455892).