### PR TITLE
fix: set working directory before running cargo fmt

### DIFF
--- a/src/cli/example.rs
+++ b/src/cli/example.rs
@@ -278,6 +278,9 @@ impl Example {
 
         build_file_tree(file_tree, &app_dir)?;
 
+        // cargo fmt needs to be run inside the Rust project folder
+        std::env::set_current_dir(&app_dir)?;
+
         if let Err(e) = run_cargo_fmt_if_available() {
             println!(
                 "{}: {}",


### PR DESCRIPTION
Addresses #508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures code formatting runs inside the newly created app directory during scaffolding, so new Rust projects are correctly formatted out of the box.
  * Applies the same behavior after scaffolding examples, improving consistency across flows (e.g., HelloWorld and Forum).
  * Improves reliability of the formatting step without altering existing error handling or requiring additional setup from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->