### PR TITLE
fix: repair logic to throw meaningful error if scaffolding with nix setup is attempted in an existing git repo

### DIFF
--- a/src/cli/example.rs
+++ b/src/cli/example.rs
@@ -50,6 +50,7 @@ pub struct Example {
 
 impl Example {
     pub async fn run(self, template_type: &TemplateType) -> anyhow::Result<()> {
+        let command_root_dir = std::env::current_dir()?;
         let template_file_tree = template_type.file_tree()?;
         let template_name = template_type.name();
         let is_vanilla_template = matches!(template_type, TemplateType::Vanilla);
@@ -67,7 +68,7 @@ impl Example {
         };
         let example_name = example.to_string();
 
-        let app_dir = std::env::current_dir()?.join(&example_name);
+        let app_dir = command_root_dir.join(&example_name);
         if app_dir.as_path().exists() {
             return Err(ScaffoldError::FolderAlreadyExists(app_dir.clone()))?;
         }
@@ -286,7 +287,7 @@ impl Example {
 
         // set up nix
         if let Some(true) | None = self.setup_nix {
-            if let Err(err) = setup_nix_developer_environment(&app_dir) {
+            if let Err(err) = setup_nix_developer_environment(&command_root_dir, &app_dir) {
                 fs::remove_dir_all(&app_dir).await?;
                 return Err(err)?;
             }

--- a/src/cli/web_app.rs
+++ b/src/cli/web_app.rs
@@ -51,7 +51,7 @@ pub struct WebApp {
 
 impl WebApp {
     pub async fn run(self, template_type: &TemplateType) -> anyhow::Result<()> {
-        let current_dir = std::env::current_dir()?;
+        let command_root_dir = std::env::current_dir()?;
         let name = match self.name {
             Some(n) => {
                 validate_input(&n, "app name")?;
@@ -60,7 +60,7 @@ impl WebApp {
             None => input_no_whitespace("App name (no whitespaces):")?,
         };
 
-        let app_folder = current_dir.join(&name);
+        let app_folder = command_root_dir.join(&name);
 
         if app_folder.as_path().exists() {
             return Err(ScaffoldError::FolderAlreadyExists(app_folder.clone()))?;
@@ -104,7 +104,7 @@ impl WebApp {
         let mut nix_instructions = "";
 
         if setup_nix {
-            if let Err(err) = setup_nix_developer_environment(&app_folder) {
+            if let Err(err) = setup_nix_developer_environment(&command_root_dir, &app_folder) {
                 fs::remove_dir_all(&app_folder).await?;
                 return Err(err)?;
             }
@@ -118,7 +118,7 @@ impl WebApp {
         if !disable_fast_track
             && input_yes_or_no("Do you want to scaffold an initial DNA? (y/n)", None)?
         {
-            WebApp::scaffold_initial_dna_and_zomes(&name, template_file_tree, &current_dir)?;
+            WebApp::scaffold_initial_dna_and_zomes(&name, template_file_tree, &command_root_dir)?;
         } else {
             disable_fast_track = true;
         }

--- a/src/scaffold/app/git.rs
+++ b/src/scaffold/app/git.rs
@@ -23,11 +23,8 @@ pub fn setup_git_environment<P: AsRef<Path>>(path: P) -> ScaffoldResult<()> {
     Ok(())
 }
 
-pub fn is_inside_work_tree<P: AsRef<Path>>(dir: P) -> bool {
-    match Repository::open(dir) {
-        Ok(repo) => repo.is_bare(),
-        Err(_) => false,
-    }
+pub fn is_inside_git_repo<P: AsRef<Path>>(dir: P) -> bool {
+    Repository::open(dir).is_ok()
 }
 
 pub fn gitignore() -> &'static str {


### PR DESCRIPTION
- Addresses #509 by fixing the logic that broke in #363 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection of Git repositories.
  * Consistent handling of the command/root directory so scaffold commands behave predictably.
  * Improved cleanup and clearer error feedback when environment setup fails; guidance provided when setup conflicts with an existing repo.

* **Refactor**
  * Unified use of a single command root across the scaffold flow.
  * Environment setup now differentiates repository root and application directory for greater stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->