### PR TITLE
Remove `dev.0` from 0.600.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "holochain_scaffolding_cli"
-version = "0.600.0-dev.0"
+version = "0.600.0"
 description = "CLI to easily generate and modify holochain apps"
 license = "CAL-1.0"
 homepage = "https://developer.holochain.org"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.600.0 as a stable release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->