### PR TITLE
build: bump holochain 0.6.1-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,9 +998,9 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "fixt"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20f2db2cbe99353c4c5e26046ebcb77e0335bd0b70a79bf963ca7ff97e8f0658"
+checksum = "1bdc290782e7b2c913ef460e0e42553c679e3a1fc48cd1826cd7423bec7859e1"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -1330,9 +1330,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "holo_hash"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4d7ada0089a52dc48498e4deab38c056b665a666b5f8717161c8d0248fd31e"
+checksum = "e6178ff6eb66e5b860d96121abec2654f9337601606690231f372716905656b0"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -1354,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23114491d121f97fe2d5095b412cfcb84c009187bfe1fcaca6c32ff0119f1a4b"
+checksum = "9f9c8f509510e3a88853b69592ca344a88d3f8f0d087f41d8ee3692b81bde0ba"
 dependencies = [
  "derive_builder",
  "holo_hash",
@@ -1374,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788bc4d6249f03bbaf3e3003fdb8cbb1fabefc7a4ccd156e13891ab97b3252bc"
+checksum = "040d2b62bf9a2a0d0d34e9363bb541407dfe09b8ff0b106364066854e045d6ac"
 dependencies = [
  "base64",
  "derive_more 2.0.1",
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da59d1c721c95502fee9a346a34fab6fd6364a39eb5e78f19688ff9cb9abbb"
+checksum = "e8d641bc9d33ad91e38696511683e652d0577a5683c3ecc2bf588d8684268d61"
 dependencies = [
  "getrandom 0.3.4",
  "holochain_secure_primitive",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_scaffolding_cli"
-version = "0.600.1"
+version = "0.600.1-rc.0"
 dependencies = [
  "anyhow",
  "build-fs-tree",
@@ -1450,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e28bdc1ec5fc4a8a7d96a95d12762297fe5c819b881273b2927d2fa19456ded"
+checksum = "b087fb6c567804e53f9f0baa59dea3b4ead384913b4cbb8f07c0476f7176589b"
 dependencies = [
  "paste",
  "serde",
@@ -1486,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1aa0a5bdc8e85e16d2867ef3be51e9e3a7d5e3e8fc5783602fbf59d561f9493"
+checksum = "d05b05e2b26856f7b9567cfd2cf3d2ea30d55291c0c6382acb2560fd3ca24786"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_timestamp"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6baf669811b4b70912408b9191127836a1a38c9ea690bcaa4c245d09fcf9253"
+checksum = "744a1ef07045a17a0dcc2fed5ccf7fc6c17fa5c3b732c46f832cf729bfdae597"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_trace"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ec6a516d857ccc4e4894b9aebb82bfe679a03343dfba1c1011a737a837de2d3"
+checksum = "cf01232f7caaca824b88d34de7254a516bd32b42dce0f230dded8af09c71edf9"
 dependencies = [
  "chrono",
  "derive_more 2.0.1",
@@ -1557,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8bdeb03038e8766a31eaea7b8056f3ba05cea579f21ca6f27b3419eaea99680"
+checksum = "9e669e4a6aca31fa41e219c253986c2dfefd382375065fa28e7be0fc9eface04"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d10cf3ca40b04f1e180817d9b059d1fe11b3e05e3127c0a5f0ad4651ddad6cb"
+checksum = "0b47bb9647fce71e41d7a934549a27786517fc84632e04f89d686c50592f96ae"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -1635,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b31902b3b626e91bfcc0f102bd04fe065eca18f10dab4b15e058d55cd5958f"
+checksum = "f528c8d5fcef58ccf4731836f96ef3e5548a404b51afa2a1760df1112169ce6e"
 dependencies = [
  "derive_builder",
  "derive_more 2.0.1",
@@ -1982,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_api"
-version = "0.3.0"
+version = "0.4.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a52f645777c05b13fa20c1d97fb1359fc4ff0391a02bf08b7cf907e5e735a3c"
+checksum = "d238cf93e1df4e89016ed527cc7f5cb0e3394c6a6a125d2057aa6b3561d084b3"
 dependencies = [
  "base64",
  "bytes",
@@ -2241,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "mr_bundle"
-version = "0.6.0"
+version = "0.6.1-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c37488b9e75bf10de7fcea730b4fbfaab95c7b1325b227025363d4c9c06df12"
+checksum = "1508cdfc51c4b5051d10004777a87d85675f4b76e28ff7c5b795de5f64b28f0e"
 dependencies = [
  "bytes",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "holochain_scaffolding_cli"
-version = "0.600.1"
+version = "0.600.1-rc.0"
 description = "CLI to easily generate and modify holochain apps"
 license = "CAL-1.0"
 homepage = "https://developer.holochain.org"
@@ -18,8 +18,8 @@ name = "holochain_scaffolding_cli"
 path = "src/lib.rs"
 
 [dependencies]
-holochain_types = "0.6.0"
-mr_bundle = "0.6.0"
+holochain_types = "0.6.1-rc.0"
+mr_bundle = "0.6.1-rc.0"
 
 dirs = "6.0"
 ignore = "0.4"

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1763511871,
-        "narHash": "sha256-KKZWi+ij7oT0Ag8yC6MQkzfHGcytyjMJDD+47ZV1YNU=",
+        "lastModified": 1768873933,
+        "narHash": "sha256-CfyzdaeLNGkyAHp3kT5vjvXhA1pVVK7nyDziYxCPsNk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "099f9014bc8d0cd6e445470ea1df0fd691d5a548",
+        "rev": "0bda7e7d005ccb5522a76d11ccfbf562b71953ca",
         "type": "github"
       },
       "original": {
@@ -20,49 +20,32 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1762980239,
-        "narHash": "sha256-8oNVE8TrD19ulHinjaqONf9QWCKK+w4url56cdStMpM=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "52a2caecc898d0b46b2b905f058ccc5081f842da",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "hc-launch": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1764005928,
-        "narHash": "sha256-M1KiSMltyhLMsIageC3rCeVHnlzQU/8lwdGTNpf8Yhk=",
-        "owner": "holochain",
-        "repo": "hc-launch",
-        "rev": "b19fe6be4edff94043b7936496f5604bf7917e97",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "holochain-0.6",
-        "repo": "hc-launch",
         "type": "github"
       }
     },
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1764011819,
-        "narHash": "sha256-dGFCjYlgvGiQQx0ubpYh2hf39+YjIirekeo/ZABe21Q=",
+        "lastModified": 1764163563,
+        "narHash": "sha256-KigJ3h25yNJfeQunPm5QYFPtLSk6nU3IEEvZY8w01Vo=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "2d71d47b9a2fec079671f3f385e01c238dee7f7e",
+        "rev": "87e997a7361d4aa7c1bb96261483ebba50223bd0",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.600.0",
+        "ref": "v0.600.1",
         "repo": "scaffolding",
         "type": "github"
       }
@@ -70,16 +53,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1763554421,
-        "narHash": "sha256-uCVTHeoJpDcc3Ky6gXt1oZX7XxVL3CmY9pFVQ5AEXtM=",
+        "lastModified": 1769035817,
+        "narHash": "sha256-PVUIsifOy6fRcceBZraLKrPwq83MzRYyfuxDCohv514=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "a6d4e805a0971ccbc0dcb3f3ed6a9e2fac980a3b",
+        "rev": "b499bd881580f9e0dd8f4494aafd4b2093a06168",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.0",
+        "ref": "holochain-0.6.1-rc.0",
         "repo": "holochain",
         "type": "github"
       }
@@ -88,21 +71,19 @@
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
-        "hc-launch": "hc-launch",
         "hc-scaffold": "hc-scaffold",
         "holochain": "holochain",
         "kitsune2": "kitsune2",
         "lair-keystore": "lair-keystore",
         "nixpkgs": "nixpkgs",
-        "playground": "playground",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1764018549,
-        "narHash": "sha256-iyxJGQAgKrw8alaHKHfomZiZ1JbsxoHg4wrXYR3ReMY=",
+        "lastModified": 1769045727,
+        "narHash": "sha256-sYGlDJ6pNt3n+Tu5F86Lsr8ki+TfGMRGeSrDz+MSv+w=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "f6fcefbe6cb3733fad39c83c6b6110eac6ca8a58",
+        "rev": "7b46630e1bd47b25d1f6385d8e921435f453c1a7",
         "type": "github"
       },
       "original": {
@@ -115,16 +96,16 @@
     "kitsune2": {
       "flake": false,
       "locked": {
-        "lastModified": 1763403287,
-        "narHash": "sha256-dqQJMoDbcD0ekttrv5+8ph5Yf25EdXwKktsxNjV57Iw=",
+        "lastModified": 1767421208,
+        "narHash": "sha256-hPIesp4R8/8sA+Qqw1ECgsgCOKlyX5coGR+7QDoavWw=",
         "owner": "holochain",
         "repo": "kitsune2",
-        "rev": "22de6e42100aa960d05f5f30427a236ad922bd80",
+        "rev": "77471c1fb4b6f926609bf82152dc97e26457b4d9",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.3.2",
+        "ref": "v0.4.0-dev.2",
         "repo": "kitsune2",
         "type": "github"
       }
@@ -148,49 +129,32 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763622513,
-        "narHash": "sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB+19M=",
+        "lastModified": 1768940263,
+        "narHash": "sha256-sJERJIYTKPFXkoz/gBaBtRKke82h4DkX3BBSsKbfbvI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c58bc7f5459328e4afac201c5c4feb7c818d604b",
+        "rev": "3ceaaa8bc963ced4d830e06ea2d0863b6490ff03",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1761765539,
-        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "playground": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1756729856,
-        "narHash": "sha256-xJnIfcIyLRTXsf+N8OOMnqzRkx2gT/DSta7qCm8yU7Y=",
-        "owner": "darksoil-studio",
-        "repo": "holochain-playground",
-        "rev": "5e858641de8ac6113cfa6b47ea1350762a629a61",
-        "type": "github"
-      },
-      "original": {
-        "owner": "darksoil-studio",
-        "ref": "main",
-        "repo": "holochain-playground",
         "type": "github"
       }
     },
@@ -223,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763692705,
-        "narHash": "sha256-tCKCyMYU0Vy+ph/xswlNsYXXjnFVweWBV+ew/5FS9tA=",
+        "lastModified": 1768963622,
+        "narHash": "sha256-n6VHiUgrYD9yjagzG6ncVVqFbVTsKCI54tR9PNAFCo0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6fbf5d328dce1828d887b8ee7d44a785196a34e7",
+        "rev": "2ef5b3362af585a83bafd34e7fc9b1f388c2e5e2",
         "type": "github"
       },
       "original": {

--- a/src/cli/custom-template/README.md
+++ b/src/cli/custom-template/README.md
@@ -17,7 +17,7 @@ nix run github:<TODO:REPLACE_ME_WITH_CUSTOM_TEMPLATE_GIT_URL>#app -- web-app
   description = "Flake for Holochain app development";
 
   inputs = {
-    holonix.url = "github:holochain/holonix?ref=main";
+    holonix.url = "github:holochain/holonix?ref=main-0.6";
     nixpkgs.follows = "holonix/nixpkgs";
     flake-parts.follows = "holonix/flake-parts";
 

--- a/src/cli/custom-template/flake.nix
+++ b/src/cli/custom-template/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     holonix.url = "github:holochain/holonix?ref=main-0.6";
-    scaffolding.url = "github:holochain/scaffolding/holochain-weekly";
+    scaffolding.url = "github:holochain/scaffolding/holochain-0.6";
     nixpkgs.follows = "holonix/nixpkgs";
     flake-parts.follows = "holonix/flake-parts";
   };

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,17 +1,18 @@
 /// npm: <https://www.npmjs.com/package/@holochain/tryorama>
+/// Note: Tryorama is no longer maintained. This version is outdated.
 pub const TRYORAMA_VERSION: &str = "^0.19.0";
 
 /// npm: <https://www.npmjs.com/package/@holochain/client>
-pub const HOLOCHAIN_CLIENT_VERSION: &str = "^0.20.0";
+pub const HOLOCHAIN_CLIENT_VERSION: &str = "^0.20.3-rc.0";
 
 /// npm: <https://www.npmjs.com/package/@holochain/hc-spin>
-pub const HC_SPIN_VERSION: &str = "^0.600.0";
+pub const HC_SPIN_VERSION: &str = "^0.600.1-rc.0";
 
 /// crates.io <https://crates.io/crates/hdi/versions>
-pub const HDI_VERSION: &str = "0.7.0";
+pub const HDI_VERSION: &str = "0.7.1-rc.0";
 
 /// crates.io <https://crates.io/crates/hdk/versions>
-pub const HDK_VERSION: &str = "0.6.0";
+pub const HDK_VERSION: &str = "0.6.1-rc.0";
 
 /// crates.io <https://crates.io/crates/holochain/versions>
-pub const HOLOCHAIN_VERSION: &str = "0.6.0";
+pub const HOLOCHAIN_VERSION: &str = "0.6.1-rc.0";


### PR DESCRIPTION
(Previous PR was based on wrong branch).

Note that ci tests fail, because they rely on tryorama, which will not be updated to support 0.6.1. It will soon be replaced with sweettest.