### PR TITLE
Refactor/replace tryorama with sweettest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,6 +1434,7 @@ dependencies = [
  "mr_bundle",
  "path-clean",
  "pluralizer",
+ "pretty_assertions",
  "prettyplease",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,6 @@ git2 = { version = "0.19.0", default-features = false, features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }
+
+[dev-dependencies]
+pretty_assertions = "1.4"

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1763511871,
-        "narHash": "sha256-KKZWi+ij7oT0Ag8yC6MQkzfHGcytyjMJDD+47ZV1YNU=",
+        "lastModified": 1766194365,
+        "narHash": "sha256-4AFsUZ0kl6MXSm4BaQgItD0VGlEKR3iq7gIaL7TjBvc=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "099f9014bc8d0cd6e445470ea1df0fd691d5a548",
+        "rev": "7d8ec2c71771937ab99790b45e6d9b93d15d9379",
         "type": "github"
       },
       "original": {
@@ -20,49 +20,32 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1762980239,
-        "narHash": "sha256-8oNVE8TrD19ulHinjaqONf9QWCKK+w4url56cdStMpM=",
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "52a2caecc898d0b46b2b905f058ccc5081f842da",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "hc-launch": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1763633869,
-        "narHash": "sha256-eRv1oT9be14R0x8hhs5PWPRKX2QC6rmrtEkmnuvvetA=",
-        "owner": "holochain",
-        "repo": "hc-launch",
-        "rev": "0bc4854dc5359340ff5b0ba00dc8ce970a43184e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "holochain-weekly",
-        "repo": "hc-launch",
         "type": "github"
       }
     },
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1760566803,
-        "narHash": "sha256-fWflEEb2JQyVHfGglbx6dCR6X+4ECGM9pbxQYrKSZtQ=",
+        "lastModified": 1764163563,
+        "narHash": "sha256-KigJ3h25yNJfeQunPm5QYFPtLSk6nU3IEEvZY8w01Vo=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "751a16e98ddb35db5763cbf4b882a849b642e7e7",
+        "rev": "87e997a7361d4aa7c1bb96261483ebba50223bd0",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "0.600.0-dev.0",
+        "ref": "v0.600.1",
         "repo": "scaffolding",
         "type": "github"
       }
@@ -70,16 +53,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1763554421,
-        "narHash": "sha256-uCVTHeoJpDcc3Ky6gXt1oZX7XxVL3CmY9pFVQ5AEXtM=",
+        "lastModified": 1769992510,
+        "narHash": "sha256-hYq8p1BiPR+AdiOgeOPV+Gz+aTs2t5yu3V8lBGctBkE=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "a6d4e805a0971ccbc0dcb3f3ed6a9e2fac980a3b",
+        "rev": "5194f7af4f71db22dd22dc37cf8c1e68d0b6d628",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.0",
+        "ref": "holochain-0.7.0-dev.10",
         "repo": "holochain",
         "type": "github"
       }
@@ -88,7 +71,6 @@
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
-        "hc-launch": "hc-launch",
         "hc-scaffold": "hc-scaffold",
         "holochain": "holochain",
         "kitsune2": "kitsune2",
@@ -98,11 +80,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1763654899,
-        "narHash": "sha256-o4V5QiJAlZHK7jf/GxCrlhtuu+W0ljMDp6wb8DOMRrQ=",
+        "lastModified": 1770041899,
+        "narHash": "sha256-UchsbnENU+rtzGcomt/bYaKxzslmiMMdQ5yvDz1B5oo=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "d21b35431e425e615bc05da790987380a84b8280",
+        "rev": "07c86551953839680bdc7f3b8bd22fbcafd156c5",
         "type": "github"
       },
       "original": {
@@ -148,27 +130,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763334038,
-        "narHash": "sha256-LBVOyaH6NFzQ3X/c6vfMZ9k4SV2ofhpxeL9YnhHNJQQ=",
+        "lastModified": 1766201043,
+        "narHash": "sha256-eplAP+rorKKd0gNjV3rA6+0WMzb1X1i16F5m5pASnjA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c8cdd5b1a630e8f72c9dd9bf582b1afb3127d2c",
+        "rev": "b3aad468604d3e488d627c0b43984eb60e75e782",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1761765539,
-        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
@@ -223,11 +205,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763519912,
-        "narHash": "sha256-N2YN0ZNBoz2zRRjmATePp9GbmGSGpVh3+piXn6mtgKc=",
+        "lastModified": 1766371695,
+        "narHash": "sha256-W7CX9vy7H2Jj3E8NI4djHyF8iHSxKpb2c/7uNQ/vGFU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a9c35d6e7cb70c5719170b6c2d3bb589c5e048af",
+        "rev": "d81285ba8199b00dc31847258cae3c655b605e8c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
               hn-introspect
               rust
             ]) ++ (with pkgs; [
-              nodejs_22
+              nodejs_24
               binaryen
             ]) ++ [
               self'.packages.hc-scaffold

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -xe
 
 TEMPLATE_PATH="/tmp"
 
@@ -79,7 +79,6 @@ setup_and_build_hello_world() {
   nix develop --command bash -c "
     set -e
     npm install
-    npm run test
     npm run package
 
     cargo clippy --all -- -D warnings

--- a/src/cli/custom-template/flake.nix
+++ b/src/cli/custom-template/flake.nix
@@ -16,7 +16,7 @@
       devShells.default = pkgs.mkShell {
         inputsFrom = [ inputs'.holonix.devShells.default ];
 
-        packages = (with pkgs; [ nodejs_22 binaryen ]);
+        packages = (with pkgs; [ nodejs_24 binaryen ]);
 
         shellHook = ''
           export PS1='\[\033[1;34m\][holonix:\w]\$\[\033[0m\] '

--- a/src/scaffold/entry_type.rs
+++ b/src/scaffold/entry_type.rs
@@ -168,6 +168,9 @@ inadvertently reference or expect elements from the skipped entry type."#
         )?;
     }
 
+    // Save the integrity zome manifest before switching to coordinator zome
+    let integrity_zome_manifest = zome_file_tree.zome_manifest.clone();
+
     let mut zome_file_tree =
         ZomeFileTree::from_zome_manifest(zome_file_tree.dna_file_tree, coordinator_zome.clone())?;
 
@@ -190,6 +193,7 @@ inadvertently reference or expect elements from the skipped entry type."#
         template_file_tree,
         &app_name,
         &dna_manifest.name(),
+        &integrity_zome_manifest,
         &coordinator_zome,
         &entry_def,
         &entry_def_ts_types,

--- a/src/templates/collection.rs
+++ b/src/templates/collection.rs
@@ -67,7 +67,7 @@ pub fn scaffold_collection_templates(
         }
         if no_spec {
             web_app_template.dir_content_mut().map(|v| {
-                v.retain(|k, _| k != "tests");
+                v.retain(|k, _| k != "tests" && k != "dnas");
                 v
             });
         }
@@ -91,4 +91,271 @@ pub fn scaffold_collection_templates(
         file_tree: app_file_tree,
         next_instructions,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scaffold::web_app::template_type::TemplateType;
+    use build_fs_tree::{dir, file};
+    use std::path::PathBuf;
+
+    struct CollectionTestParams {
+        reference_entry_hash: bool,
+        collection_type: CollectionType,
+        deletable: bool,
+    }
+
+    fn render_collection_test(params: &CollectionTestParams) -> String {
+        let app_file_tree: FileTree = dir! {
+            "dnas" => dir! {
+                "test_dna" => dir! {
+                    "zomes" => dir! {
+                        "coordinator" => dir! {
+                            "test_zome" => dir! {
+                                "src" => dir! {
+                                    "lib.rs" => file!("")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        let template_file_tree = TemplateType::Vanilla.file_tree().unwrap();
+        let coordinator_zome_manifest = ZomeManifest {
+            name: "test_zome".into(),
+            hash: None,
+            path: "test.wasm".into(),
+            dependencies: None,
+        };
+        let entry_type_reference = EntryTypeReference {
+            entry_type: "TestPost".to_string(),
+            reference_entry_hash: params.reference_entry_hash,
+        };
+
+        let result = scaffold_collection_templates(
+            app_file_tree,
+            &template_file_tree,
+            "test_app",
+            "test_dna",
+            &coordinator_zome_manifest,
+            &params.collection_type,
+            "all_posts",
+            &entry_type_reference,
+            params.deletable,
+            false,
+            false,
+        )
+        .unwrap();
+
+        let coordinator_zome_path = PathBuf::from("dnas/test_dna/zomes/coordinator/test_zome");
+        file_content(
+            &result.file_tree,
+            &coordinator_zome_path.join("tests/all-posts.rs"),
+        )
+        .unwrap()
+    }
+
+    fn expected_collection_test(params: &CollectionTestParams) -> String {
+        let reference = if params.reference_entry_hash {
+            "create_record.signed_action.hashed.content.entry_hash().unwrap().clone().into()"
+        } else {
+            "create_record.signed_action.hashed.hash.clone().into()"
+        };
+
+        let posts_by = if matches!(params.collection_type, CollectionType::ByAuthor) {
+            "alice_zome.cell_id().agent_pubkey().clone()"
+        } else {
+            "()"
+        };
+
+        let delete_section = if params.deletable && !params.reference_entry_hash {
+            format!(
+                r#"
+
+    // Alice deletes the TestPost
+    let _delete_action_hash: ActionHash = alice_conductor
+        .call(
+            &alice_zome,
+            "delete_test_post",
+            create_record.signed_action.hashed.hash.clone(),
+        )
+        .await;
+
+    // Wait for the entry deletion to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+
+    // Bob gets all posts again
+    let collection_output: Vec<Link> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_all_posts",
+            {posts_by},
+        )
+        .await;
+    assert_eq!(collection_output.len(), 0);"#
+            )
+        } else {
+            "".to_string()
+        };
+
+        format!(
+            r#"use holochain::prelude::*;
+use holochain::sweettest::*;
+use std::path::Path;
+
+mod common;
+use common::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_a_test_post_and_get_all_posts() {{
+    // Create conductors with the standard config
+    let mut conductors = SweetConductorBatch::standard(2).await;
+    let dna_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../workdir/test_dna.dna");
+    let dna_file = SweetDnaFile::from_bundle(&dna_path).await.unwrap();
+    let apps = conductors.setup_app("test-app", &[dna_file]).await.unwrap();
+    let cells = apps.cells_flattened();
+    let alice_conductor = conductors.get(0).unwrap();
+    let alice_zome = cells[0].zome("test_zome");
+    let bob_conductor = conductors.get(1).unwrap();
+    let bob_zome = cells[1].zome("test_zome");
+
+    // Bob gets all posts
+    let collection_output: Vec<Link> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_all_posts",
+            {posts_by},
+        )
+        .await;
+    assert_eq!(collection_output.len(), 0);
+
+    // Alice creates a TestPost
+    let create_record: Record = create_test_post(&alice_conductor, &alice_zome).await;
+
+    // Wait for the created entry to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+
+    // Bob gets all posts again
+    let collection_output: Vec<Link> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_all_posts",
+            {posts_by},
+        )
+        .await;
+    assert_eq!(collection_output.len(), 1);
+    assert_eq!(
+        collection_output[0].target,
+        {reference}
+    );{delete_section}
+}}
+"#
+        )
+    }
+
+    #[test]
+    fn scaffold_collection_global() {
+        let params = CollectionTestParams {
+            reference_entry_hash: false,
+            collection_type: CollectionType::Global,
+            deletable: false,
+        };
+        pretty_assertions::assert_str_eq!(
+            render_collection_test(&params),
+            expected_collection_test(&params)
+        );
+    }
+
+    #[test]
+    fn scaffold_collection_reference_entry_hash_global() {
+        let params = CollectionTestParams {
+            reference_entry_hash: true,
+            collection_type: CollectionType::Global,
+            deletable: false,
+        };
+        pretty_assertions::assert_str_eq!(
+            render_collection_test(&params),
+            expected_collection_test(&params)
+        );
+    }
+
+    #[test]
+    fn scaffold_collection_global_deletable() {
+        let params = CollectionTestParams {
+            reference_entry_hash: false,
+            collection_type: CollectionType::Global,
+            deletable: true,
+        };
+        pretty_assertions::assert_str_eq!(
+            render_collection_test(&params),
+            expected_collection_test(&params)
+        );
+    }
+
+    #[test]
+    fn scaffold_collection_reference_entry_hash_global_deletable() {
+        let params = CollectionTestParams {
+            reference_entry_hash: true,
+            collection_type: CollectionType::Global,
+            deletable: true,
+        };
+        pretty_assertions::assert_str_eq!(
+            render_collection_test(&params),
+            expected_collection_test(&params)
+        );
+    }
+
+    #[test]
+    fn scaffold_collection_by_author() {
+        let params = CollectionTestParams {
+            reference_entry_hash: false,
+            collection_type: CollectionType::ByAuthor,
+            deletable: false,
+        };
+        pretty_assertions::assert_str_eq!(
+            render_collection_test(&params),
+            expected_collection_test(&params)
+        );
+    }
+
+    #[test]
+    fn scaffold_collection_reference_entry_hash_by_author() {
+        let params = CollectionTestParams {
+            reference_entry_hash: true,
+            collection_type: CollectionType::ByAuthor,
+            deletable: false,
+        };
+        pretty_assertions::assert_str_eq!(
+            render_collection_test(&params),
+            expected_collection_test(&params)
+        );
+    }
+
+    #[test]
+    fn scaffold_collection_reference_entry_hash_by_author_deletable() {
+        let params = CollectionTestParams {
+            reference_entry_hash: true,
+            collection_type: CollectionType::ByAuthor,
+            deletable: true,
+        };
+        pretty_assertions::assert_str_eq!(
+            render_collection_test(&params),
+            expected_collection_test(&params)
+        );
+    }
+
+    #[test]
+    fn scaffold_collection_by_author_deletable() {
+        let params = CollectionTestParams {
+            reference_entry_hash: false,
+            collection_type: CollectionType::ByAuthor,
+            deletable: true,
+        };
+        pretty_assertions::assert_str_eq!(
+            render_collection_test(&params),
+            expected_collection_test(&params)
+        );
+    }
 }

--- a/src/templates/entry_type.rs
+++ b/src/templates/entry_type.rs
@@ -13,10 +13,14 @@ use super::{
     build_handlebars, render_template_file_tree_and_merge_with_existing, ScaffoldedTemplate,
 };
 
+#[cfg(test)]
+mod tests;
+
 #[derive(Serialize, Debug)]
 pub struct ScaffoldEntryTypeData<'a> {
     pub app_name: String,
     pub dna_role_name: String,
+    pub integrity_zome_manifest: ZomeManifest,
     pub coordinator_zome_manifest: ZomeManifest,
     pub entry_type: EntryDefinition,
     pub entry_type_ts_types: &'a str,
@@ -31,6 +35,7 @@ pub fn scaffold_entry_type_templates(
     template_file_tree: &FileTree,
     app_name: &str,
     dna_role_name: &str,
+    integrity_zome: &ZomeManifest,
     coordinator_zome: &ZomeManifest,
     entry_type: &EntryDefinition,
     entry_type_ts_types: &str,
@@ -42,6 +47,7 @@ pub fn scaffold_entry_type_templates(
     let data = ScaffoldEntryTypeData {
         app_name: app_name.to_owned(),
         dna_role_name: dna_role_name.to_owned(),
+        integrity_zome_manifest: integrity_zome.clone(),
         coordinator_zome_manifest: coordinator_zome.clone(),
         entry_type: entry_type.clone(),
         entry_type_ts_types,
@@ -63,7 +69,7 @@ pub fn scaffold_entry_type_templates(
         }
         if no_spec {
             web_app_template.dir_content_mut().map(|v| {
-                v.retain(|k, _| k != "tests");
+                v.retain(|k, _| k != "tests" && k != "dnas");
                 v
             });
         }

--- a/src/templates/entry_type/tests.rs
+++ b/src/templates/entry_type/tests.rs
@@ -1,0 +1,3 @@
+mod entry_type;
+
+mod common;

--- a/src/templates/entry_type/tests/common.rs
+++ b/src/templates/entry_type/tests/common.rs
@@ -1,0 +1,734 @@
+use super::super::*;
+use crate::scaffold::{
+    entry_type::definitions::{
+        Cardinality, EntryTypeReference, FieldDefinition, FieldType, Referenceable,
+    },
+    web_app::template_type::TemplateType,
+};
+
+const INTEGRITY_ZOME_NAME: &str = "test_zome_integrity";
+
+fn render_template(entry_type: EntryDefinition) -> String {
+    let template_file_tree = TemplateType::Svelte.file_tree().unwrap();
+    let h = build_handlebars(&template_file_tree).unwrap();
+    let common_template_content = file_content(
+        &template_file_tree,
+        &PathBuf::from("entry-type/dnas/{{dna_role_name}}/zomes/coordinator/{{coordinator_zome_manifest.name}}/tests/common.rs.hbs"),
+    )
+    .unwrap();
+
+    let data = ScaffoldEntryTypeData {
+        app_name: "test-app".to_string(),
+        dna_role_name: "test-dna".to_string(),
+        integrity_zome_manifest: ZomeManifest {
+            name: INTEGRITY_ZOME_NAME.into(),
+            path: "zome_integrity".to_string(),
+            dependencies: None,
+            hash: None,
+        },
+        coordinator_zome_manifest: ZomeManifest {
+            name: "test-zome".into(),
+            path: "zome".to_string(),
+            dependencies: None,
+            hash: None,
+        },
+        entry_type,
+        entry_type_ts_types: "",
+        crud: Crud::default(),
+        link_from_original_to_each_update: false,
+    };
+    h.render_template(&common_template_content, &data).unwrap()
+}
+
+fn expected_common(return_value: &str) -> String {
+    format!(
+        r#"use hdk::prelude::*;
+use holochain::sweettest::{{SweetConductor, SweetZome}};
+use {INTEGRITY_ZOME_NAME}::*;
+
+pub async fn sample_test_entry(conductor: &SweetConductor, zome: &SweetZome) -> TestEntry {{
+    {return_value}
+}}
+
+pub async fn create_test_entry(conductor: &SweetConductor, zome: &SweetZome) -> Record {{
+    conductor
+        .call(&zome, "create_test_entry", sample_test_entry(conductor, zome).await)
+        .await
+}}
+"#
+    )
+}
+
+#[test]
+fn single_string() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::String,
+            cardinality: Cardinality::Single,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: Default::default(),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn single_bool() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::Bool,
+            cardinality: Cardinality::Single,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: Default::default(),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn single_u8() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::U8,
+            cardinality: Cardinality::Single,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: Default::default(),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn single_agent_pub_key() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::AgentPubKey,
+            cardinality: Cardinality::Single,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: AgentPubKey::from_raw_36(vec![0; 36]),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn single_action_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ActionHash,
+            cardinality: Cardinality::Single,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: ActionHash::from_raw_36(vec![0; 36]),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn single_entry_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::EntryHash,
+            cardinality: Cardinality::Single,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: EntryHash::from_raw_36(vec![0; 36]),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn single_dna_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::DnaHash,
+            cardinality: Cardinality::Single,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: DnaHash::from_raw_36(vec![0; 36]),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn single_external_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ExternalHash,
+            cardinality: Cardinality::Single,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: ExternalHash::from_raw_36(vec![0; 36]),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn single_timestamp() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::Timestamp,
+            cardinality: Cardinality::Single,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: Timestamp::now(),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn single_enum() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::Enum {
+                label: "TestEnum".to_string(),
+                variants: vec!["Variant1".to_string(), "Variant2".to_string()],
+            },
+            cardinality: Cardinality::Single,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+    let expected_return_value = r#"TestEntry {
+        test_field: TestEnum::Variant1,
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn vector() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::String,
+            cardinality: Cardinality::Vector,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: Vec::new(),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn single_action_hash_linked_from_action_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ActionHash,
+            cardinality: Cardinality::Single,
+            linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                entry_type: "other_test_entry".to_string(),
+                reference_entry_hash: false,
+            })),
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+    let expected_return_value = r#"TestEntry {
+        test_field: create_other_test_entry(conductor, zome).await.signed_action.hashed.hash,
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn single_action_hash_linked_from_entry_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ActionHash,
+            cardinality: Cardinality::Single,
+            linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                entry_type: "other_test_entry".to_string(),
+                reference_entry_hash: true,
+            })),
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: create_other_test_entry(conductor, zome).await.signed_action.hashed.content.entry_hash().unwrap().clone(),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn single_action_hash_linked_from_agent_pub_key() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ActionHash,
+            cardinality: Cardinality::Single,
+            linked_from: Some(Referenceable::Agent {
+                role: "perpetrator".to_string(),
+            }),
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+    let expected_return_value = r#"TestEntry {
+        test_field: zome.cell_id().agent_pubkey().clone(),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn option_action_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ActionHash,
+            cardinality: Cardinality::Option,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: None,
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn option_agent_pub_key() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::AgentPubKey,
+            cardinality: Cardinality::Option,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: None,
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn option_bool() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::Bool,
+            cardinality: Cardinality::Option,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: None,
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn option_dna_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::DnaHash,
+            cardinality: Cardinality::Option,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: None,
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn option_enum() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::Enum {
+                label: "TestEnum".to_string(),
+                variants: vec!["Variant1".to_string()],
+            },
+            cardinality: Cardinality::Option,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: None,
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn option_timestamp() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::Timestamp,
+            cardinality: Cardinality::Option,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: None,
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn option_string() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::String,
+            cardinality: Cardinality::Option,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: None,
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn option_external_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ExternalHash,
+            cardinality: Cardinality::Option,
+            linked_from: None,
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: None,
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn option_linked_from_self_reference() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ActionHash,
+            cardinality: Cardinality::Option,
+            linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                entry_type: "test_entry".to_string(),
+                reference_entry_hash: false,
+            })),
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: None,
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn option_linked_from_agent_pub_key() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::AgentPubKey,
+            cardinality: Cardinality::Option,
+            linked_from: Some(Referenceable::Agent {
+                role: "NailClipper".to_string(),
+            }),
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: Some(zome.cell_id().agent_pubkey().clone()),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn option_linked_from_action_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ActionHash,
+            cardinality: Cardinality::Option,
+            linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                entry_type: "other_test_entry".to_string(),
+                reference_entry_hash: false,
+            })),
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: Some(create_other_test_entry(conductor, zome).await.signed_action.hashed.hash),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn option_linked_from_entry_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ActionHash,
+            cardinality: Cardinality::Option,
+            linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                entry_type: "other_test_entry".to_string(),
+                reference_entry_hash: true,
+            })),
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: Some(create_other_test_entry(conductor, zome).await.signed_action.hashed.content.entry_hash().unwrap().clone()),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn vector_action_hash_linked_from_self_reference() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ActionHash,
+            cardinality: Cardinality::Vector,
+            linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                entry_type: "test_entry".to_string(),
+                reference_entry_hash: false,
+            })),
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: Vec::new(),
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn vector_action_hash_linked_from_action_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ActionHash,
+            cardinality: Cardinality::Vector,
+            linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                entry_type: "other_test_entry".to_string(),
+                reference_entry_hash: false,
+            })),
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: vec![create_other_test_entry(conductor, zome).await.signed_action.hashed.hash],
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn vector_action_hash_linked_from_entry_hash() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "test_field".to_string(),
+            field_type: FieldType::ActionHash,
+            cardinality: Cardinality::Vector,
+            linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                entry_type: "other_test_entry".to_string(),
+                reference_entry_hash: true,
+            })),
+            widget: None,
+        }],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: vec![create_other_test_entry(conductor, zome).await.signed_action.hashed.content.entry_hash().unwrap().clone()],
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}
+
+#[test]
+fn two_single_fields() {
+    let entry_type = EntryDefinition {
+        name: "test_entry".to_string(),
+        fields: vec![
+            FieldDefinition {
+                field_name: "test_field".to_string(),
+                field_type: FieldType::String,
+                cardinality: Cardinality::Single,
+                linked_from: None,
+                widget: None,
+            },
+            FieldDefinition {
+                field_name: "test_field_2".to_string(),
+                field_type: FieldType::ActionHash,
+                cardinality: Cardinality::Single,
+                linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                    entry_type: "other_test_entry".to_string(),
+                    reference_entry_hash: false,
+                })),
+                widget: None,
+            },
+        ],
+        reference_entry_hash: false,
+    };
+    let rendered_common = render_template(entry_type);
+
+    let expected_return_value = r#"TestEntry {
+        test_field: Default::default(),
+        test_field_2: create_other_test_entry(conductor, zome).await.signed_action.hashed.hash,
+    }"#;
+    pretty_assertions::assert_str_eq!(rendered_common, expected_common(expected_return_value));
+}

--- a/src/templates/entry_type/tests/entry_type.rs
+++ b/src/templates/entry_type/tests/entry_type.rs
@@ -1,0 +1,1108 @@
+use super::super::*;
+use crate::scaffold::entry_type::definitions::{
+    Cardinality, EntryTypeReference, FieldDefinition, Referenceable,
+};
+use crate::scaffold::web_app::template_type::TemplateType;
+use crate::{file_tree::file_exists, scaffold::entry_type::definitions::FieldType};
+use build_fs_tree::{dir, file, FileSystemTree};
+
+// Expected string helpers
+
+fn expected_header(entry_type_name: &str) -> String {
+    format!(
+        r#"use holochain::prelude::*;
+use holochain::sweettest::*;
+use std::path::Path;
+use test_zome::{entry_type_name}::*;
+use test_zome_integrity::*;
+
+mod common;
+use common::*;
+"#
+    )
+}
+
+fn expected_create_test(
+    entry_type_name_snake_case: &str,
+    entry_type_name_pascal_case: &str,
+) -> String {
+    format!(
+        r#"
+#[tokio::test(flavor = "multi_thread")]
+async fn create_{entry_type_name_snake_case}() {{
+    // Create a conductor with the standard config
+    let mut conductor = SweetConductor::standard().await;
+    let dna_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../workdir/test_dna.dna");
+    let dna_file = SweetDnaFile::from_bundle(&dna_path).await.unwrap();
+    let app = conductor.setup_app("test-app", &[dna_file]).await.unwrap();
+    let zome = app.cells()[0].zome("test_zome");
+
+    let {entry_type_name_snake_case} = sample_{entry_type_name_snake_case}(&conductor, &zome).await;
+
+    // Agent creates a {entry_type_name_pascal_case}
+    let _: Record = conductor.call(&zome, "create_{entry_type_name_snake_case}", {entry_type_name_snake_case}.clone()).await;
+}}
+"#
+    )
+}
+
+fn expected_create_and_read_test(
+    entry_type_name_snake_case: &str,
+    entry_type_name_pascal_case: &str,
+    get_fn_name: &str,
+    hash_access: &str,
+    linked_from: Option<&str>,
+) -> String {
+    let linked_from_section = linked_from
+        .map(|field_access| {
+            format!(
+                r#"
+
+    // Bob gets the {entry_type_name_pascal_case}s for the new TestPost
+    let links_to_test_posts: Vec<Link> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_{entry_type_name_snake_case}s_for_test_post",
+            {entry_type_name_pascal_case}::try_from({entry_type_name_snake_case}.clone()).unwrap().{field_access},
+        )
+        .await;
+    assert_eq!(links_to_test_posts.len(), 1);
+    assert_eq!(
+        links_to_test_posts[0].target,
+        record.signed_action.hashed.{hash_access}.into()
+    );"#
+            )
+        })
+        .unwrap_or_default();
+
+    format!(
+        r#"
+#[tokio::test(flavor = "multi_thread")]
+async fn create_and_read_{entry_type_name_snake_case}() {{
+    // Create conductors with the standard config
+    let mut conductors = SweetConductorBatch::standard(2).await;
+    let dna_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../workdir/test_dna.dna");
+    let dna_file = SweetDnaFile::from_bundle(&dna_path).await.unwrap();
+    let apps = conductors.setup_app("test-app", &[dna_file]).await.unwrap();
+    let cells = apps.cells_flattened();
+    let alice_conductor = conductors.get(0).unwrap();
+    let alice_zome = cells[0].zome("test_zome");
+    let bob_conductor = conductors.get(1).unwrap();
+    let bob_zome = cells[1].zome("test_zome");
+
+    let {entry_type_name_snake_case} = sample_{entry_type_name_snake_case}(&alice_conductor, &alice_zome).await;
+
+    // Alice creates a {entry_type_name_pascal_case}
+    let record: Record = alice_conductor
+        .call(&alice_zome, "create_{entry_type_name_snake_case}", {entry_type_name_snake_case}.clone())
+        .await;
+
+    // Wait for the created entry to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+
+    // Bob gets the created {entry_type_name_pascal_case}
+    let propagated_record: Record = bob_conductor
+        .call(
+            &bob_zome,
+            "{get_fn_name}",
+            record.signed_action.hashed.{hash_access},
+        )
+        .await;
+    assert_eq!(record, propagated_record);{linked_from_section}
+}}
+"#
+    )
+}
+
+fn expected_update_test(
+    entry_type_name_snake_case: &str,
+    entry_type_name_pascal_case: &str,
+    link_from_original_to_each_update: bool,
+) -> String {
+    let maybe_original_hash = if link_from_original_to_each_update {
+        format!(
+            r#"
+        original_{entry_type_name_snake_case}_hash: original_action_hash.clone(),"#
+        )
+    } else {
+        "".to_string()
+    };
+
+    format!(
+        r#"
+#[tokio::test(flavor = "multi_thread")]
+async fn create_and_update_{entry_type_name_snake_case}() {{
+    // Create conductors with the standard config
+    let mut conductors = SweetConductorBatch::standard(2).await;
+    let dna_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../workdir/test_dna.dna");
+    let dna_file = SweetDnaFile::from_bundle(&dna_path).await.unwrap();
+    let apps = conductors.setup_app("test-app", &[dna_file]).await.unwrap();
+    let cells = apps.cells_flattened();
+    let alice_conductor = conductors.get(0).unwrap();
+    let alice_zome = cells[0].zome("test_zome");
+    let bob_conductor = conductors.get(1).unwrap();
+    let bob_zome = cells[1].zome("test_zome");
+
+    let {entry_type_name_snake_case} = sample_{entry_type_name_snake_case}(&alice_conductor, &alice_zome).await;
+
+    // Alice creates a {entry_type_name_pascal_case}
+    let record: Record = alice_conductor
+        .call(&alice_zome, "create_{entry_type_name_snake_case}", {entry_type_name_snake_case}.clone())
+        .await;
+
+    let original_action_hash = record.signed_action.hashed.hash.clone();
+
+    // Alice updates the {entry_type_name_pascal_case}
+    let content_update = sample_{entry_type_name_snake_case}(&alice_conductor, &alice_zome).await;
+    let update_input = Update{entry_type_name_pascal_case}Input {{{maybe_original_hash}
+        previous_{entry_type_name_snake_case}_hash: original_action_hash.clone(),
+        updated_{entry_type_name_snake_case}: content_update.clone(),
+    }};
+    let updated_record: Record = alice_conductor
+        .call(&alice_zome, "update_{entry_type_name_snake_case}", update_input)
+        .await;
+
+    // Wait for the updated entry to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+
+    // Bob gets the updated {entry_type_name_pascal_case}
+    let read_updated_record_1: Record = bob_conductor
+        .call(
+            &bob_zome,
+            "get_latest_{entry_type_name_snake_case}",
+            updated_record.signed_action.hashed.hash.clone(),
+        )
+        .await;
+    assert_eq!(updated_record, read_updated_record_1);
+
+    // Alice updates the {entry_type_name_pascal_case} again
+    let content_update = sample_{entry_type_name_snake_case}(&alice_conductor, &alice_zome).await;
+    let update_input = Update{entry_type_name_pascal_case}Input {{{maybe_original_hash}
+        previous_{entry_type_name_snake_case}_hash: updated_record.signed_action.hashed.hash.clone(),
+        updated_{entry_type_name_snake_case}: content_update.clone(),
+    }};
+    let updated_record: Record = alice_conductor
+        .call(&alice_zome, "update_{entry_type_name_snake_case}", update_input)
+        .await;
+
+    // Wait for the updated entry to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+
+    // Bob gets the updated {entry_type_name_pascal_case}
+    let read_updated_record_2: Record = bob_conductor
+        .call(
+            &bob_zome,
+            "get_latest_{entry_type_name_snake_case}",
+            updated_record.signed_action.hashed.hash.clone(),
+        )
+        .await;
+    let RecordEntry::Present(entry) = read_updated_record_2.entry else {{
+        panic!(
+            "Expected Present entry, got {{:?}}",
+            read_updated_record_2.entry
+        );
+    }};
+    assert_eq!({entry_type_name_pascal_case}::try_from(entry.clone()).unwrap(), content_update);
+
+    // Bob gets all the revisions for {entry_type_name_pascal_case}
+    let revisions: Vec<Record> = bob_conductor
+        .call(&bob_zome, "get_all_revisions_for_{entry_type_name_snake_case}", original_action_hash)
+        .await;
+    assert_eq!(revisions.len(), 3);
+    let RecordEntry::Present(ref entry) = revisions[2].entry else {{
+        panic!("Expected Present entry, got {{:?}}", revisions[2].entry);
+    }};
+    assert_eq!({entry_type_name_pascal_case}::try_from(entry).unwrap(), content_update);
+}}
+"#
+    )
+}
+
+fn expected_delete_test(
+    entry_type_name_snake_case: &str,
+    entry_type_name_pascal_case: &str,
+    hash_access: &str,
+    linked_from: Option<&str>,
+) -> String {
+    let linked_from_section_before_delete = linked_from
+        .map(|field_access| {
+            format!(
+                r#"
+
+    // Bob gets the {entry_type_name_pascal_case}s for the new TestPost
+    let links_to_test_posts: Vec<Link> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_{entry_type_name_snake_case}s_for_test_post",
+            {entry_type_name_pascal_case}::try_from({entry_type_name_snake_case}.clone()).unwrap().{field_access},
+        )
+        .await;
+    assert_eq!(links_to_test_posts.len(), 1);
+    assert_eq!(
+        links_to_test_posts[0].target,
+        record.signed_action.hashed.{hash_access}.into()
+    );"#
+            )
+        })
+        .unwrap_or_default();
+
+    let linked_from_section_after_delete = linked_from
+        .map(|field_access| {
+            format!(
+                r#"
+
+    // Bob gets the {entry_type_name_pascal_case}s for the TestPost again
+    let links_to_test_posts: Vec<Link> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_{entry_type_name_snake_case}s_for_test_post",
+            {entry_type_name_pascal_case}::try_from({entry_type_name_snake_case}.clone()).unwrap().{field_access},
+        )
+        .await;
+    assert_eq!(links_to_test_posts.len(), 0);
+
+    // Bob gets the deleted {entry_type_name_pascal_case} for the TestPosts
+    let deleted_links_to_test_posts: Vec<(SignedActionHashed, Vec<SignedActionHashed>)> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_deleted_{entry_type_name_snake_case}s_for_test_post",
+            {entry_type_name_pascal_case}::try_from({entry_type_name_snake_case}.clone()).unwrap().{field_access},
+        )
+        .await;
+    assert_eq!(deleted_links_to_test_posts.len(), 1);"#
+            )
+        })
+        .unwrap_or_default();
+
+    format!(
+        r#"
+#[tokio::test(flavor = "multi_thread")]
+async fn create_and_delete_{entry_type_name_snake_case}() {{
+    // Create conductors with the standard config
+    let mut conductors = SweetConductorBatch::standard(2).await;
+    let dna_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../workdir/test_dna.dna");
+    let dna_file = SweetDnaFile::from_bundle(&dna_path).await.unwrap();
+    let apps = conductors.setup_app("test-app", &[dna_file]).await.unwrap();
+    let cells = apps.cells_flattened();
+    let alice_conductor = conductors.get(0).unwrap();
+    let alice_zome = cells[0].zome("test_zome");
+    let bob_conductor = conductors.get(1).unwrap();
+    let bob_zome = cells[1].zome("test_zome");
+
+    let {entry_type_name_snake_case} = sample_{entry_type_name_snake_case}(&alice_conductor, &alice_zome).await;
+
+    // Alice creates a {entry_type_name_pascal_case}
+    let record: Record = alice_conductor
+        .call(&alice_zome, "create_{entry_type_name_snake_case}", {entry_type_name_snake_case}.clone())
+        .await;
+
+    // Wait for the created entry to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();{linked_from_section_before_delete}
+
+    // Alice deletes the {entry_type_name_pascal_case}
+    let _delete_action_hash: ActionHash = alice_conductor
+        .call(
+            &alice_zome,
+            "delete_{entry_type_name_snake_case}",
+            record.signed_action.hashed.hash.clone(),
+        )
+        .await;
+
+    // Wait for the entry deletion to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+
+    // Bob gets the oldest delete for the {entry_type_name_pascal_case}
+    let oldest_delete_for_{entry_type_name_snake_case}: Option<SignedActionHashed> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_oldest_delete_for_{entry_type_name_snake_case}",
+            record.signed_action.hashed.hash.clone(),
+        )
+        .await;
+    assert!(oldest_delete_for_{entry_type_name_snake_case}.is_some());
+
+    // Bob gets the deletions for the {entry_type_name_pascal_case}
+    let deletes_for_{entry_type_name_snake_case}: Option<Vec<SignedActionHashed>> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_all_deletes_for_{entry_type_name_snake_case}",
+            record.signed_action.hashed.hash.clone(),
+        )
+        .await;
+    assert_eq!(deletes_for_{entry_type_name_snake_case}.unwrap().len(), 1);{linked_from_section_after_delete}
+}}
+"#
+    )
+}
+
+/// Build expected test file with create-only tests
+fn expected_rendered_create_and_read(
+    entry_type_name_snake_case: &str,
+    entry_type_name_pascal_case: &str,
+    get_fn_name: &str,
+    hash_access: &str,
+    linked_from: Option<&str>,
+) -> String {
+    format!(
+        "{}{}{}",
+        expected_header(entry_type_name_snake_case),
+        expected_create_test(entry_type_name_snake_case, entry_type_name_pascal_case),
+        expected_create_and_read_test(
+            entry_type_name_snake_case,
+            entry_type_name_pascal_case,
+            get_fn_name,
+            hash_access,
+            linked_from,
+        )
+    )
+}
+
+/// Build expected test file with create + update tests
+fn expected_rendered_create_and_update(
+    entry_type_name_snake_case: &str,
+    entry_type_name_pascal_case: &str,
+    link_from_original_to_each_update: bool,
+) -> String {
+    format!(
+        "{}{}{}{}",
+        expected_header(entry_type_name_snake_case),
+        expected_create_test(entry_type_name_snake_case, entry_type_name_pascal_case),
+        expected_create_and_read_test(
+            entry_type_name_snake_case,
+            entry_type_name_pascal_case,
+            &format!("get_original_{entry_type_name_snake_case}"),
+            "hash.clone()",
+            None,
+        ),
+        expected_update_test(
+            entry_type_name_snake_case,
+            entry_type_name_pascal_case,
+            link_from_original_to_each_update
+        )
+    )
+}
+
+/// Build expected test file with create + delete tests
+fn expected_rendered_create_and_delete(
+    entry_type_name_snake_case: &str,
+    entry_type_name_pascal_case: &str,
+    hash_access: &str,
+    linked_from: Option<&str>,
+) -> String {
+    format!(
+        "{}{}{}{}",
+        expected_header(entry_type_name_snake_case),
+        expected_create_test(entry_type_name_snake_case, entry_type_name_pascal_case),
+        expected_create_and_read_test(
+            entry_type_name_snake_case,
+            entry_type_name_pascal_case,
+            &format!("get_{entry_type_name_snake_case}"),
+            "hash.clone()",
+            linked_from,
+        ),
+        expected_delete_test(
+            entry_type_name_snake_case,
+            entry_type_name_pascal_case,
+            hash_access,
+            linked_from
+        )
+    )
+}
+
+/// Build expected test file with create + update + delete tests
+fn expected_rendered_create_and_update_and_delete(
+    entry_type_name_snake_case: &str,
+    entry_type_name_pascal_case: &str,
+    link_from_original_to_each_update: bool,
+    hash_access: &str,
+    linked_from: Option<&str>,
+) -> String {
+    format!(
+        "{}{}{}{}{}",
+        expected_header(entry_type_name_snake_case),
+        expected_create_test(entry_type_name_snake_case, entry_type_name_pascal_case),
+        expected_create_and_read_test(
+            entry_type_name_snake_case,
+            entry_type_name_pascal_case,
+            &format!("get_original_{entry_type_name_snake_case}"),
+            "hash.clone()",
+            None,
+        ),
+        expected_update_test(
+            entry_type_name_snake_case,
+            entry_type_name_pascal_case,
+            link_from_original_to_each_update
+        ),
+        expected_delete_test(
+            entry_type_name_snake_case,
+            entry_type_name_pascal_case,
+            hash_access,
+            linked_from
+        )
+    )
+}
+
+// Test setup
+
+struct TestCase {
+    app_file_tree: FileTree,
+    template_file_tree: FileSystemTree<OsString, String>,
+    integrity_zome_manifest: ZomeManifest,
+    coordinator_zome_manifest: ZomeManifest,
+    coordinator_zome_path: PathBuf,
+    entry_type: EntryDefinition,
+}
+
+fn scaffold_test_entry_type() -> TestCase {
+    // Create an app file tree with the coordinator zome directory already present
+    let app_file_tree: FileTree = dir! {
+        "dnas" => dir! {
+            "test_dna" => dir! {
+                "zomes" => dir! {
+                    "coordinator" => dir! {
+                        "test_zome" => dir! {
+                            "src" => dir! {
+                                "lib.rs" => file!("")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    let template_file_tree = TemplateType::Vanilla.file_tree().unwrap();
+    let integrity_zome_manifest = ZomeManifest {
+        name: "test_zome_integrity".into(),
+        hash: None,
+        path: "test_integrity.wasm".into(),
+        dependencies: None,
+    };
+    let coordinator_zome_manifest = ZomeManifest {
+        name: "test_zome".into(),
+        hash: None,
+        path: "test.wasm".into(),
+        dependencies: None,
+    };
+    let coordinator_zome_path = PathBuf::from("dnas/test_dna/zomes/coordinator/test_zome");
+    let entry_type = EntryDefinition {
+        name: "TestPost".to_string(),
+        fields: vec![FieldDefinition {
+            field_name: "title".to_string(),
+            field_type: FieldType::String,
+            widget: Some("TextField".to_string()),
+            cardinality: Cardinality::Single,
+            linked_from: None,
+        }],
+        reference_entry_hash: false,
+    };
+    TestCase {
+        app_file_tree,
+        template_file_tree,
+        integrity_zome_manifest,
+        coordinator_zome_manifest,
+        coordinator_zome_path,
+        entry_type,
+    }
+}
+
+#[test]
+fn scaffold_entry_type_creates_test_files() {
+    let TestCase {
+        app_file_tree,
+        template_file_tree,
+        integrity_zome_manifest,
+        coordinator_zome_manifest,
+        coordinator_zome_path,
+        entry_type,
+    } = scaffold_test_entry_type();
+    let crud = Crud::default();
+
+    let result = scaffold_entry_type_templates(
+        app_file_tree,
+        &template_file_tree,
+        "test_app",
+        "test_dna",
+        &integrity_zome_manifest,
+        &coordinator_zome_manifest,
+        &entry_type,
+        "",
+        &crud,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+
+    assert!(file_exists(
+        &result.file_tree,
+        &coordinator_zome_path.join("tests/test-post.rs")
+    ));
+    assert!(file_exists(
+        &result.file_tree,
+        &coordinator_zome_path.join("tests/common.rs")
+    ));
+}
+
+#[test]
+fn scaffold_entry_type_create() {
+    let TestCase {
+        app_file_tree,
+        template_file_tree,
+        integrity_zome_manifest,
+        coordinator_zome_manifest,
+        coordinator_zome_path,
+        entry_type,
+    } = scaffold_test_entry_type();
+    let crud = Crud {
+        update: false,
+        delete: false,
+    };
+
+    let result = scaffold_entry_type_templates(
+        app_file_tree,
+        &template_file_tree,
+        "test_app",
+        "test_dna",
+        &integrity_zome_manifest,
+        &coordinator_zome_manifest,
+        &entry_type,
+        "",
+        &crud,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let scaffolded_test_file = file_content(
+        &result.file_tree,
+        &coordinator_zome_path.join("tests/test-post.rs"),
+    )
+    .unwrap();
+
+    pretty_assertions::assert_str_eq!(
+        scaffolded_test_file,
+        expected_rendered_create_and_read(
+            "test_post",
+            &entry_type.name,
+            "get_test_post",
+            "hash.clone()",
+            None,
+        )
+    );
+}
+
+#[test]
+fn scaffold_entry_type_create_with_entry_hash_reference() {
+    let TestCase {
+        app_file_tree,
+        template_file_tree,
+        integrity_zome_manifest,
+        coordinator_zome_manifest,
+        coordinator_zome_path,
+        mut entry_type,
+    } = scaffold_test_entry_type();
+    let crud = Crud {
+        update: false,
+        delete: false,
+    };
+    entry_type.reference_entry_hash = true;
+
+    let result = scaffold_entry_type_templates(
+        app_file_tree,
+        &template_file_tree,
+        "test_app",
+        "test_dna",
+        &integrity_zome_manifest,
+        &coordinator_zome_manifest,
+        &entry_type,
+        "",
+        &crud,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let scaffolded_test_file = file_content(
+        &result.file_tree,
+        &coordinator_zome_path.join("tests/test-post.rs"),
+    )
+    .unwrap();
+
+    pretty_assertions::assert_str_eq!(
+        scaffolded_test_file,
+        expected_rendered_create_and_read(
+            "test_post",
+            &entry_type.name,
+            "get_test_post",
+            "content.entry_hash().unwrap().clone()",
+            None,
+        )
+    );
+}
+
+#[test]
+fn scaffold_entry_type_create_update() {
+    let TestCase {
+        app_file_tree,
+        template_file_tree,
+        integrity_zome_manifest,
+        coordinator_zome_manifest,
+        coordinator_zome_path,
+        entry_type,
+    } = scaffold_test_entry_type();
+    let crud = Crud {
+        update: true,
+        delete: false,
+    };
+
+    let result = scaffold_entry_type_templates(
+        app_file_tree,
+        &template_file_tree,
+        "test_app",
+        "test_dna",
+        &integrity_zome_manifest,
+        &coordinator_zome_manifest,
+        &entry_type,
+        "",
+        &crud,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let scaffolded_test_file = file_content(
+        &result.file_tree,
+        &coordinator_zome_path.join("tests/test-post.rs"),
+    )
+    .unwrap();
+
+    pretty_assertions::assert_str_eq!(
+        scaffolded_test_file,
+        expected_rendered_create_and_update("test_post", &entry_type.name, false)
+    );
+}
+
+#[test]
+fn scaffold_entry_type_create_update_link_from_original_to_each_update() {
+    let TestCase {
+        app_file_tree,
+        template_file_tree,
+        integrity_zome_manifest,
+        coordinator_zome_manifest,
+        coordinator_zome_path,
+        entry_type,
+    } = scaffold_test_entry_type();
+    let crud = Crud {
+        update: true,
+        delete: false,
+    };
+
+    let result = scaffold_entry_type_templates(
+        app_file_tree,
+        &template_file_tree,
+        "test_app",
+        "test_dna",
+        &integrity_zome_manifest,
+        &coordinator_zome_manifest,
+        &entry_type,
+        "",
+        &crud,
+        true,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let scaffolded_test_file = file_content(
+        &result.file_tree,
+        &coordinator_zome_path.join("tests/test-post.rs"),
+    )
+    .unwrap();
+
+    pretty_assertions::assert_str_eq!(
+        scaffolded_test_file,
+        expected_rendered_create_and_update("test_post", &entry_type.name, true)
+    );
+}
+
+#[test]
+fn scaffold_entry_type_create_update_delete() {
+    let TestCase {
+        app_file_tree,
+        template_file_tree,
+        integrity_zome_manifest,
+        coordinator_zome_manifest,
+        coordinator_zome_path,
+        entry_type,
+    } = scaffold_test_entry_type();
+    let crud = Crud {
+        update: true,
+        delete: true,
+    };
+
+    let result = scaffold_entry_type_templates(
+        app_file_tree,
+        &template_file_tree,
+        "test_app",
+        "test_dna",
+        &integrity_zome_manifest,
+        &coordinator_zome_manifest,
+        &entry_type,
+        "",
+        &crud,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let scaffolded_test_file = file_content(
+        &result.file_tree,
+        &coordinator_zome_path.join("tests/test-post.rs"),
+    )
+    .unwrap();
+
+    pretty_assertions::assert_str_eq!(
+        scaffolded_test_file,
+        expected_rendered_create_and_update_and_delete(
+            "test_post",
+            &entry_type.name,
+            false,
+            "hash.clone()",
+            None
+        )
+    );
+}
+
+#[test]
+fn scaffold_entry_type_create_delete() {
+    let TestCase {
+        app_file_tree,
+        template_file_tree,
+        integrity_zome_manifest,
+        coordinator_zome_manifest,
+        coordinator_zome_path,
+        entry_type,
+    } = scaffold_test_entry_type();
+    let crud = Crud {
+        update: false,
+        delete: true,
+    };
+
+    let result = scaffold_entry_type_templates(
+        app_file_tree,
+        &template_file_tree,
+        "test_app",
+        "test_dna",
+        &integrity_zome_manifest,
+        &coordinator_zome_manifest,
+        &entry_type,
+        "",
+        &crud,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let scaffolded_test_file = file_content(
+        &result.file_tree,
+        &coordinator_zome_path.join("tests/test-post.rs"),
+    )
+    .unwrap();
+
+    pretty_assertions::assert_str_eq!(
+        scaffolded_test_file,
+        expected_rendered_create_and_delete("test_post", &entry_type.name, "hash.clone()", None)
+    );
+}
+
+#[test]
+fn scaffold_entry_type_create_linked_from() {
+    // Scaffold a test entry with a field that links to another entry.
+    let TestCase {
+        app_file_tree,
+        template_file_tree,
+        integrity_zome_manifest,
+        coordinator_zome_manifest,
+        coordinator_zome_path,
+        ..
+    } = scaffold_test_entry_type();
+    let entry_type = EntryDefinition {
+        name: "TestComment".to_string(),
+        fields: vec![
+            FieldDefinition {
+                field_name: "test_comment".to_string(),
+                field_type: FieldType::String,
+                widget: None,
+                cardinality: Cardinality::Single,
+                linked_from: None,
+            },
+            FieldDefinition {
+                field_name: "test_post_hash".to_string(),
+                field_type: FieldType::String,
+                widget: None,
+                cardinality: Cardinality::Single,
+                linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                    entry_type: "test_post".to_string(),
+                    reference_entry_hash: false,
+                })),
+            },
+        ],
+        reference_entry_hash: false,
+    };
+    let crud = Crud {
+        update: false,
+        delete: false,
+    };
+    let result = scaffold_entry_type_templates(
+        app_file_tree,
+        &template_file_tree,
+        "test_app",
+        "test_dna",
+        &integrity_zome_manifest,
+        &coordinator_zome_manifest,
+        &entry_type,
+        "",
+        &crud,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let scaffolded_test_file = file_content(
+        &result.file_tree,
+        &coordinator_zome_path.join("tests/test-comment.rs"),
+    )
+    .unwrap();
+    pretty_assertions::assert_str_eq!(
+        scaffolded_test_file,
+        expected_rendered_create_and_read(
+            "test_comment",
+            "TestComment",
+            "get_test_comment",
+            "hash.clone()",
+            Some("test_post_hash")
+        )
+    );
+}
+
+#[test]
+fn scaffold_entry_type_create_linked_from_with_entry_hash_reference() {
+    // Test the linked_from path with reference_entry_hash: true
+    let TestCase {
+        app_file_tree,
+        template_file_tree,
+        integrity_zome_manifest,
+        coordinator_zome_manifest,
+        coordinator_zome_path,
+        ..
+    } = scaffold_test_entry_type();
+    let entry_type = EntryDefinition {
+        name: "TestComment".to_string(),
+        fields: vec![
+            FieldDefinition {
+                field_name: "test_comment".to_string(),
+                field_type: FieldType::String,
+                widget: None,
+                cardinality: Cardinality::Single,
+                linked_from: None,
+            },
+            FieldDefinition {
+                field_name: "test_post_hash".to_string(),
+                field_type: FieldType::EntryHash,
+                widget: None,
+                cardinality: Cardinality::Single,
+                linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                    entry_type: "test_post".to_string(),
+                    reference_entry_hash: false,
+                })),
+            },
+        ],
+        reference_entry_hash: true,
+    };
+    let crud = Crud {
+        update: false,
+        delete: false,
+    };
+    let result = scaffold_entry_type_templates(
+        app_file_tree,
+        &template_file_tree,
+        "test_app",
+        "test_dna",
+        &integrity_zome_manifest,
+        &coordinator_zome_manifest,
+        &entry_type,
+        "",
+        &crud,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let scaffolded_test_file = file_content(
+        &result.file_tree,
+        &coordinator_zome_path.join("tests/test-comment.rs"),
+    )
+    .unwrap();
+    // Verify the entry_hash path is used in the linked_from assertion
+    pretty_assertions::assert_str_eq!(
+        scaffolded_test_file,
+        expected_rendered_create_and_read(
+            "test_comment",
+            &entry_type.name,
+            "get_test_comment",
+            "content.entry_hash().unwrap().clone()",
+            Some("test_post_hash"),
+        )
+    );
+}
+
+#[test]
+fn scaffold_entry_type_create_linked_from_vector() {
+    // Scaffold a test entry with a field that links to another entry.
+    let TestCase {
+        app_file_tree,
+        template_file_tree,
+        integrity_zome_manifest,
+        coordinator_zome_manifest,
+        coordinator_zome_path,
+        ..
+    } = scaffold_test_entry_type();
+    let entry_type = EntryDefinition {
+        name: "TestComment".to_string(),
+        fields: vec![
+            FieldDefinition {
+                field_name: "test_comment".to_string(),
+                field_type: FieldType::String,
+                widget: None,
+                cardinality: Cardinality::Single,
+                linked_from: None,
+            },
+            FieldDefinition {
+                field_name: "test_post_hash".to_string(),
+                field_type: FieldType::String,
+                widget: None,
+                cardinality: Cardinality::Vector,
+                linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                    entry_type: "test_post".to_string(),
+                    reference_entry_hash: false,
+                })),
+            },
+        ],
+        reference_entry_hash: false,
+    };
+    let crud = Crud {
+        update: false,
+        delete: false,
+    };
+    let result = scaffold_entry_type_templates(
+        app_file_tree,
+        &template_file_tree,
+        "test_app",
+        "test_dna",
+        &integrity_zome_manifest,
+        &coordinator_zome_manifest,
+        &entry_type,
+        "",
+        &crud,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let scaffolded_test_file = file_content(
+        &result.file_tree,
+        &coordinator_zome_path.join("tests/test-comment.rs"),
+    )
+    .unwrap();
+    // Verify the vector field uses [0] index access
+    pretty_assertions::assert_str_eq!(
+        scaffolded_test_file,
+        expected_rendered_create_and_read(
+            "test_comment",
+            &entry_type.name,
+            "get_test_comment",
+            "hash.clone()",
+            Some("test_post_hash[0]"),
+        ),
+        "Expected vector field to use [0] index access. Got:\n{scaffolded_test_file}"
+    );
+}
+
+#[test]
+fn scaffold_entry_type_create_delete_linked_from() {
+    let TestCase {
+        app_file_tree,
+        template_file_tree,
+        integrity_zome_manifest,
+        coordinator_zome_manifest,
+        coordinator_zome_path,
+        ..
+    } = scaffold_test_entry_type();
+    let entry_type = EntryDefinition {
+        name: "TestComment".to_string(),
+        fields: vec![
+            FieldDefinition {
+                field_name: "test_comment".to_string(),
+                field_type: FieldType::String,
+                widget: None,
+                cardinality: Cardinality::Single,
+                linked_from: None,
+            },
+            FieldDefinition {
+                field_name: "test_post_hash".to_string(),
+                field_type: FieldType::String,
+                widget: None,
+                cardinality: Cardinality::Single,
+                linked_from: Some(Referenceable::EntryType(EntryTypeReference {
+                    entry_type: "test_post".to_string(),
+                    reference_entry_hash: false,
+                })),
+            },
+        ],
+        reference_entry_hash: false,
+    };
+    let crud = Crud {
+        update: false,
+        delete: true,
+    };
+
+    let result = scaffold_entry_type_templates(
+        app_file_tree,
+        &template_file_tree,
+        "test_app",
+        "test_dna",
+        &integrity_zome_manifest,
+        &coordinator_zome_manifest,
+        &entry_type,
+        "",
+        &crud,
+        false,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let scaffolded_test_file = file_content(
+        &result.file_tree,
+        &coordinator_zome_path.join("tests/test-comment.rs"),
+    )
+    .unwrap();
+
+    pretty_assertions::assert_str_eq!(
+        scaffolded_test_file,
+        expected_rendered_create_and_delete(
+            "test_comment",
+            &entry_type.name,
+            "hash.clone()",
+            Some("test_post_hash")
+        )
+    );
+}

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -2,16 +2,16 @@
 pub const TRYORAMA_VERSION: &str = "^0.19.0";
 
 /// npm: <https://www.npmjs.com/package/@holochain/client>
-pub const HOLOCHAIN_CLIENT_VERSION: &str = "^0.20.0";
+pub const HOLOCHAIN_CLIENT_VERSION: &str = "^0.21.0-dev.2";
 
 /// npm: <https://www.npmjs.com/package/@holochain/hc-spin>
-pub const HC_SPIN_VERSION: &str = "^0.600.0";
+pub const HC_SPIN_VERSION: &str = "^0.700.0-dev.0";
 
 /// crates.io <https://crates.io/crates/hdi/versions>
-pub const HDI_VERSION: &str = "0.7.0";
+pub const HDI_VERSION: &str = "0.8.0-dev.4";
 
 /// crates.io <https://crates.io/crates/hdk/versions>
-pub const HDK_VERSION: &str = "0.6.0";
+pub const HDK_VERSION: &str = "0.7.0-dev.6";
 
 /// crates.io <https://crates.io/crates/holochain/versions>
-pub const HOLOCHAIN_VERSION: &str = "0.6.0";
+pub const HOLOCHAIN_VERSION: &str = "0.7.0-dev.9";

--- a/templates/generic/collection/dnas/{{dna_role_name}}/zomes/coordinator/{{coordinator_zome_manifest.name}}/tests/{{kebab_case collection_name}}.rs.hbs
+++ b/templates/generic/collection/dnas/{{dna_role_name}}/zomes/coordinator/{{coordinator_zome_manifest.name}}/tests/{{kebab_case collection_name}}.rs.hbs
@@ -1,0 +1,74 @@
+use holochain::prelude::*;
+use holochain::sweettest::*;
+use std::path::Path;
+
+mod common;
+use common::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_a_{{snake_case referenceable.name}}_and_get_{{snake_case collection_name}}() {
+    // Create conductors with the standard config
+    let mut conductors = SweetConductorBatch::standard(2).await;
+    let dna_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../workdir/{{dna_role_name}}.dna");
+    let dna_file = SweetDnaFile::from_bundle(&dna_path).await.unwrap();
+    let apps = conductors.setup_app("test-app", &[dna_file]).await.unwrap();
+    let cells = apps.cells_flattened();
+    let alice_conductor = conductors.get(0).unwrap();
+    let alice_zome = cells[0].zome("{{coordinator_zome_manifest.name}}");
+    let bob_conductor = conductors.get(1).unwrap();
+    let bob_zome = cells[1].zome("{{coordinator_zome_manifest.name}}");
+
+    // Bob gets {{lower_case collection_name}}
+    let collection_output: Vec<Link> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_{{snake_case collection_name}}",
+            {{#if (eq collection_type.type "ByAuthor")}}alice_zome.cell_id().agent_pubkey().clone(){{else}}(){{/if}},
+        )
+        .await;
+    assert_eq!(collection_output.len(), 0);
+
+    // Alice creates a {{pascal_case referenceable.name}}
+    let create_record: Record = create_{{snake_case referenceable.name}}(&alice_conductor, &alice_zome).await;
+
+    // Wait for the created entry to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+
+    // Bob gets {{lower_case collection_name}} again
+    let collection_output: Vec<Link> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_{{snake_case collection_name}}",
+            {{#if (eq collection_type.type "ByAuthor")}}alice_zome.cell_id().agent_pubkey().clone(){{else}}(){{/if}},
+        )
+        .await;
+    assert_eq!(collection_output.len(), 1);
+    assert_eq!(
+        collection_output[0].target,
+        {{#if (eq referenceable.hash_type "EntryHash")}}create_record.signed_action.hashed.content.entry_hash().unwrap().clone().into(){{else}}create_record.signed_action.hashed.hash.clone().into(){{/if}}
+    );
+{{#if (and deletable (eq referenceable.hash_type "ActionHash"))}}
+
+    // Alice deletes the {{pascal_case referenceable.name}}
+    let _delete_action_hash: ActionHash = alice_conductor
+        .call(
+            &alice_zome,
+            "delete_{{snake_case referenceable.name}}",
+            create_record.signed_action.hashed.hash.clone(),
+        )
+        .await;
+
+    // Wait for the entry deletion to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+
+    // Bob gets {{lower_case collection_name}} again
+    let collection_output: Vec<Link> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_{{snake_case collection_name}}",
+            {{#if (eq collection_type.type "ByAuthor")}}alice_zome.cell_id().agent_pubkey().clone(){{else}}(){{/if}},
+        )
+        .await;
+    assert_eq!(collection_output.len(), 0);
+{{/if}}
+}

--- a/templates/generic/entry-type/dnas/{{dna_role_name}}/zomes/coordinator/{{coordinator_zome_manifest.name}}/tests/common.rs.hbs
+++ b/templates/generic/entry-type/dnas/{{dna_role_name}}/zomes/coordinator/{{coordinator_zome_manifest.name}}/tests/common.rs.hbs
@@ -1,0 +1,101 @@
+{{#if previous_file_content}}{{previous_file_content}}
+
+{{else}}use hdk::prelude::*;
+use holochain::sweettest::{SweetConductor, SweetZome};
+use {{snake_case coordinator_zome_manifest.name}}_integrity::*;
+
+{{/if}}pub async fn sample_{{snake_case entry_type.name}}(conductor: &SweetConductor, zome: &SweetZome) -> {{pascal_case entry_type.name}} {
+    {{pascal_case entry_type.name}} {
+{{#each entry_type.fields}}
+  {{#if linked_from}}
+    {{#if (eq cardinality "vector")}}
+      {{#if (eq (pascal_case linked_from.name) (pascal_case ../entry_type.name))}}
+        {{!-- Self-reference --}}
+        {{field_name}}: Vec::new(),
+      {{else}}
+        {{#if (eq linked_from.hash_type "ActionHash")}}
+        {{field_name}}: vec![create_{{snake_case linked_from.name}}(conductor, zome).await.signed_action.hashed.hash],
+        {{else}}
+        {{!-- EntryHash --}}
+        {{field_name}}: vec![create_{{snake_case linked_from.name}}(conductor, zome).await.signed_action.hashed.content.entry_hash().unwrap().clone()],
+        {{/if}}
+      {{/if}}
+    {{else}}
+      {{#if (eq cardinality "option")}}
+        {{!-- Self-reference --}}
+        {{#if (eq (pascal_case linked_from.name) (pascal_case ../entry_type.name))}}
+        {{field_name}}: None,
+        {{else}}
+          {{#if (eq linked_from.hash_type "AgentPubKey")}}
+        {{field_name}}: Some(zome.cell_id().agent_pubkey().clone()),
+          {{else}}
+            {{#if (eq linked_from.hash_type "ActionHash")}}
+        {{field_name}}: Some(create_{{snake_case linked_from.name}}(conductor, zome).await.signed_action.hashed.hash),
+            {{else}}
+            {{!-- EntryHash --}}
+        {{field_name}}: Some(create_{{snake_case linked_from.name}}(conductor, zome).await.signed_action.hashed.content.entry_hash().unwrap().clone()),
+            {{/if}}
+          {{/if}}
+        {{/if}}
+      {{else}}
+        {{!-- Cardinality::Single --}}
+        {{#if (eq linked_from.hash_type "AgentPubKey")}}
+        {{field_name}}: zome.cell_id().agent_pubkey().clone(),
+        {{else}}
+          {{#if (eq linked_from.hash_type "ActionHash")}}
+        {{field_name}}: create_{{snake_case linked_from.name}}(conductor, zome).await.signed_action.hashed.hash,
+          {{else}}
+        {{field_name}}: create_{{snake_case linked_from.name}}(conductor, zome).await.signed_action.hashed.content.entry_hash().unwrap().clone(),
+          {{/if}}
+        {{/if}}
+      {{/if}}
+    {{/if}}
+  {{else}}
+    {{#if (eq cardinality "vector")}}
+        {{field_name}}: Vec::new(),
+    {{else}}
+      {{#if (eq cardinality "option")}}
+        {{field_name}}: None,
+      {{else}}
+        {{!-- Cardinality::Single --}}
+        {{#if (eq field_type.type "ActionHash")}}
+        {{field_name}}: ActionHash::from_raw_36(vec![0; 36]),
+        {{else}}
+          {{#if (eq field_type.type "EntryHash")}}
+        {{field_name}}: EntryHash::from_raw_36(vec![0; 36]),
+          {{else}}
+            {{#if (eq field_type.type "AgentPubKey")}}
+        {{field_name}}: AgentPubKey::from_raw_36(vec![0; 36]),
+            {{else}}
+              {{#if (eq field_type.type "DnaHash")}}
+        {{field_name}}: DnaHash::from_raw_36(vec![0; 36]),
+              {{else}}
+                {{#if (eq field_type.type "ExternalHash")}}
+        {{field_name}}: ExternalHash::from_raw_36(vec![0; 36]),
+                {{else}}
+                  {{#if (eq field_type.type "Timestamp")}}
+        {{field_name}}: Timestamp::now(),
+                  {{else}}
+                    {{#if (eq field_type.type "Enum")}}
+        {{field_name}}: {{pascal_case field_type.label}}::{{lookup field_type.variants 0}},
+                    {{else}}
+        {{field_name}}: Default::default(),
+                    {{/if}}
+                  {{/if}}
+                {{/if}}
+              {{/if}}
+            {{/if}}
+          {{/if}}
+        {{/if}}
+      {{/if}}
+    {{/if}}
+  {{/if}}
+{{/each}}
+    }
+}
+
+pub async fn create_{{snake_case entry_type.name}}(conductor: &SweetConductor, zome: &SweetZome) -> Record {
+    conductor
+        .call(&zome, "create_{{snake_case entry_type.name}}", sample_{{snake_case entry_type.name}}(conductor, zome).await)
+        .await
+}

--- a/templates/generic/entry-type/dnas/{{dna_role_name}}/zomes/coordinator/{{coordinator_zome_manifest.name}}/tests/{{kebab_case entry_type.name}}.rs.hbs
+++ b/templates/generic/entry-type/dnas/{{dna_role_name}}/zomes/coordinator/{{coordinator_zome_manifest.name}}/tests/{{kebab_case entry_type.name}}.rs.hbs
@@ -1,0 +1,274 @@
+use holochain::prelude::*;
+use holochain::sweettest::*;
+use std::path::Path;
+use {{coordinator_zome_manifest.name}}::{{snake_case entry_type.name}}::*;
+use {{integrity_zome_manifest.name}}::*;
+
+mod common;
+use common::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_{{snake_case entry_type.name}}() {
+    // Create a conductor with the standard config
+    let mut conductor = SweetConductor::standard().await;
+    let dna_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../workdir/{{dna_role_name}}.dna");
+    let dna_file = SweetDnaFile::from_bundle(&dna_path).await.unwrap();
+    let app = conductor.setup_app("test-app", &[dna_file]).await.unwrap();
+    let zome = app.cells()[0].zome("{{coordinator_zome_manifest.name}}");
+
+    let {{snake_case entry_type.name}} = sample_{{snake_case entry_type.name}}(&conductor, &zome).await;
+
+    // Agent creates a {{pascal_case entry_type.name}}
+    let _: Record = conductor.call(&zome, "create_{{snake_case entry_type.name}}", {{snake_case entry_type.name}}.clone()).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_and_read_{{snake_case entry_type.name}}() {
+    // Create conductors with the standard config
+    let mut conductors = SweetConductorBatch::standard(2).await;
+    let dna_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../workdir/{{dna_role_name}}.dna");
+    let dna_file = SweetDnaFile::from_bundle(&dna_path).await.unwrap();
+    let apps = conductors.setup_app("test-app", &[dna_file]).await.unwrap();
+    let cells = apps.cells_flattened();
+    let alice_conductor = conductors.get(0).unwrap();
+    let alice_zome = cells[0].zome("{{coordinator_zome_manifest.name}}");
+    let bob_conductor = conductors.get(1).unwrap();
+    let bob_zome = cells[1].zome("{{coordinator_zome_manifest.name}}");
+
+    let {{snake_case entry_type.name}} = sample_{{snake_case entry_type.name}}(&alice_conductor, &alice_zome).await;
+
+    // Alice creates a {{pascal_case entry_type.name}}
+    let record: Record = alice_conductor
+        .call(&alice_zome, "create_{{snake_case entry_type.name}}", {{snake_case entry_type.name}}.clone())
+        .await;
+
+    // Wait for the created entry to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+
+    // Bob gets the created {{pascal_case entry_type.name}}
+    let propagated_record: Record = bob_conductor
+        .call(
+            &bob_zome,
+            "{{#if crud.update}}get_original_{{snake_case entry_type.name}}{{else}}get_{{snake_case entry_type.name}}{{/if}}",
+            {{#if entry_type.reference_entry_hash}}record.signed_action.hashed.content.entry_hash().unwrap().clone(){{else}}record.signed_action.hashed.hash.clone(){{/if}},
+        )
+        .await;
+    assert_eq!(record, propagated_record);
+    {{#each entry_type.fields}}
+        {{#if linked_from}}
+
+            {{#if (ne (pascal_case linked_from.name) (pascal_case ../entry_type.name))}}
+    // Bob gets the {{pascal_case (plural ../entry_type.name)}} for the new {{pascal_case linked_from.name}}
+    let links_to_{{snake_case (plural linked_from.name)}}: Vec<Link> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_{{snake_case (plural ../entry_type.name)}}_for_{{snake_case linked_from.name}}",
+            {{pascal_case ../entry_type.name}}::try_from({{snake_case ../entry_type.name}}.clone()).unwrap().{{field_name}}{{#if (eq cardinality "vector")}}[0]{{/if}},
+        )
+        .await;
+    assert_eq!(links_to_{{snake_case (plural linked_from.name)}}.len(), 1);
+    assert_eq!(
+        links_to_{{snake_case (plural linked_from.name)}}[0].target,
+        {{#if ../entry_type.reference_entry_hash}}record.signed_action.hashed.content.entry_hash().unwrap().clone().into(){{else}}record.signed_action.hashed.hash.clone().into(){{/if}}
+    );
+            {{/if}}
+        {{/if}}
+    {{/each}}
+}
+{{#if crud.update}}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_and_update_{{snake_case entry_type.name}}() {
+    // Create conductors with the standard config
+    let mut conductors = SweetConductorBatch::standard(2).await;
+    let dna_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../workdir/{{dna_role_name}}.dna");
+    let dna_file = SweetDnaFile::from_bundle(&dna_path).await.unwrap();
+    let apps = conductors.setup_app("test-app", &[dna_file]).await.unwrap();
+    let cells = apps.cells_flattened();
+    let alice_conductor = conductors.get(0).unwrap();
+    let alice_zome = cells[0].zome("{{coordinator_zome_manifest.name}}");
+    let bob_conductor = conductors.get(1).unwrap();
+    let bob_zome = cells[1].zome("{{coordinator_zome_manifest.name}}");
+
+    let {{snake_case entry_type.name}} = sample_{{snake_case entry_type.name}}(&alice_conductor, &alice_zome).await;
+
+    // Alice creates a {{pascal_case entry_type.name}}
+    let record: Record = alice_conductor
+        .call(&alice_zome, "create_{{snake_case entry_type.name}}", {{snake_case entry_type.name}}.clone())
+        .await;
+
+    let original_action_hash = record.signed_action.hashed.hash.clone();
+
+    // Alice updates the {{pascal_case entry_type.name}}
+    let content_update = sample_{{snake_case entry_type.name}}(&alice_conductor, &alice_zome).await;
+    let update_input = Update{{pascal_case entry_type.name}}Input {
+{{#if link_from_original_to_each_update}}
+        original_{{snake_case entry_type.name}}_hash: original_action_hash.clone(),
+{{/if}}
+        previous_{{snake_case entry_type.name}}_hash: original_action_hash.clone(),
+        updated_{{snake_case entry_type.name}}: content_update.clone(),
+    };
+    let updated_record: Record = alice_conductor
+        .call(&alice_zome, "update_{{snake_case entry_type.name}}", update_input)
+        .await;
+
+    // Wait for the updated entry to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+
+    // Bob gets the updated {{pascal_case entry_type.name}}
+    let read_updated_record_1: Record = bob_conductor
+        .call(
+            &bob_zome,
+            "get_latest_{{snake_case entry_type.name}}",
+            updated_record.signed_action.hashed.hash.clone(),
+        )
+        .await;
+    assert_eq!(updated_record, read_updated_record_1);
+
+    // Alice updates the {{pascal_case entry_type.name}} again
+    let content_update = sample_{{snake_case entry_type.name}}(&alice_conductor, &alice_zome).await;
+    let update_input = Update{{pascal_case entry_type.name}}Input {
+{{#if link_from_original_to_each_update}}
+        original_{{snake_case entry_type.name}}_hash: original_action_hash.clone(),
+{{/if}}
+        previous_{{snake_case entry_type.name}}_hash: updated_record.signed_action.hashed.hash.clone(),
+        updated_{{snake_case entry_type.name}}: content_update.clone(),
+    };
+    let updated_record: Record = alice_conductor
+        .call(&alice_zome, "update_{{snake_case entry_type.name}}", update_input)
+        .await;
+
+    // Wait for the updated entry to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+
+    // Bob gets the updated {{pascal_case entry_type.name}}
+    let read_updated_record_2: Record = bob_conductor
+        .call(
+            &bob_zome,
+            "get_latest_{{snake_case entry_type.name}}",
+            updated_record.signed_action.hashed.hash.clone(),
+        )
+        .await;
+    let RecordEntry::Present(entry) = read_updated_record_2.entry else {
+        panic!(
+            "Expected Present entry, got {:?}",
+            read_updated_record_2.entry
+        );
+    };
+    assert_eq!({{pascal_case entry_type.name}}::try_from(entry.clone()).unwrap(), content_update);
+
+    // Bob gets all the revisions for {{pascal_case entry_type.name}}
+    let revisions: Vec<Record> = bob_conductor
+        .call(&bob_zome, "get_all_revisions_for_{{snake_case entry_type.name}}", original_action_hash)
+        .await;
+    assert_eq!(revisions.len(), 3);
+    let RecordEntry::Present(ref entry) = revisions[2].entry else {
+        panic!("Expected Present entry, got {:?}", revisions[2].entry);
+    };
+    assert_eq!({{pascal_case entry_type.name}}::try_from(entry).unwrap(), content_update);
+}
+{{/if}}
+{{#if crud.delete}}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_and_delete_{{snake_case entry_type.name}}() {
+    // Create conductors with the standard config
+    let mut conductors = SweetConductorBatch::standard(2).await;
+    let dna_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../workdir/{{dna_role_name}}.dna");
+    let dna_file = SweetDnaFile::from_bundle(&dna_path).await.unwrap();
+    let apps = conductors.setup_app("test-app", &[dna_file]).await.unwrap();
+    let cells = apps.cells_flattened();
+    let alice_conductor = conductors.get(0).unwrap();
+    let alice_zome = cells[0].zome("{{coordinator_zome_manifest.name}}");
+    let bob_conductor = conductors.get(1).unwrap();
+    let bob_zome = cells[1].zome("{{coordinator_zome_manifest.name}}");
+
+    let {{snake_case entry_type.name}} = sample_{{snake_case entry_type.name}}(&alice_conductor, &alice_zome).await;
+
+    // Alice creates a {{pascal_case entry_type.name}}
+    let record: Record = alice_conductor
+        .call(&alice_zome, "create_{{snake_case entry_type.name}}", {{snake_case entry_type.name}}.clone())
+        .await;
+
+    // Wait for the created entry to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+  {{#each entry_type.fields}}
+    {{#if linked_from}}
+
+      {{#if (ne (pascal_case linked_from.name) (pascal_case ../entry_type.name))}}
+    // Bob gets the {{pascal_case (plural ../entry_type.name)}} for the new {{pascal_case linked_from.name}}
+    let links_to_{{snake_case (plural linked_from.name)}}: Vec<Link> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_{{snake_case (plural ../entry_type.name)}}_for_{{snake_case linked_from.name}}",
+            {{pascal_case ../entry_type.name}}::try_from({{snake_case ../entry_type.name}}.clone()).unwrap().{{field_name}}{{#if (eq cardinality "vector")}}[0]{{/if}},
+        )
+        .await;
+    assert_eq!(links_to_{{snake_case (plural linked_from.name)}}.len(), 1);
+    assert_eq!(
+        links_to_{{snake_case (plural linked_from.name)}}[0].target,
+        {{#if ../entry_type.reference_entry_hash}}record.signed_action.hashed.content.entry_hash().unwrap().clone().into(){{else}}record.signed_action.hashed.hash.clone().into(){{/if}}
+    );
+      {{/if}}
+    {{/if}}
+  {{/each}}
+
+    // Alice deletes the {{pascal_case entry_type.name}}
+    let _delete_action_hash: ActionHash = alice_conductor
+        .call(
+            &alice_zome,
+            "delete_{{snake_case entry_type.name}}",
+            record.signed_action.hashed.hash.clone(),
+        )
+        .await;
+
+    // Wait for the entry deletion to be propagated to the other node.
+    await_consistency(&cells).await.unwrap();
+
+    // Bob gets the oldest delete for the {{pascal_case entry_type.name}}
+    let oldest_delete_for_{{snake_case entry_type.name}}: Option<SignedActionHashed> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_oldest_delete_for_{{snake_case entry_type.name}}",
+            record.signed_action.hashed.hash.clone(),
+        )
+        .await;
+    assert!(oldest_delete_for_{{snake_case entry_type.name}}.is_some());
+
+    // Bob gets the deletions for the {{pascal_case entry_type.name}}
+    let deletes_for_{{snake_case entry_type.name}}: Option<Vec<SignedActionHashed>> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_all_deletes_for_{{snake_case entry_type.name}}",
+            record.signed_action.hashed.hash.clone(),
+        )
+        .await;
+    assert_eq!(deletes_for_{{snake_case entry_type.name}}.unwrap().len(), 1);
+  {{#each entry_type.fields}}
+    {{#if linked_from}}
+
+      {{#if (ne (pascal_case linked_from.name) (pascal_case ../entry_type.name))}}
+    // Bob gets the {{pascal_case (plural ../entry_type.name)}} for the {{pascal_case linked_from.name}} again
+    let links_to_{{snake_case (plural linked_from.name)}}: Vec<Link> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_{{snake_case (plural ../entry_type.name)}}_for_{{snake_case linked_from.name}}",
+            {{pascal_case ../entry_type.name}}::try_from({{snake_case ../entry_type.name}}.clone()).unwrap().{{field_name}}{{#if (eq cardinality "vector")}}[0]{{/if}},
+        )
+        .await;
+    assert_eq!(links_to_{{snake_case (plural linked_from.name)}}.len(), 0);
+
+    // Bob gets the deleted {{pascal_case ../entry_type.name}} for the {{pascal_case (plural linked_from.name)}}
+    let deleted_links_to_{{snake_case (plural linked_from.name)}}: Vec<(SignedActionHashed, Vec<SignedActionHashed>)> = bob_conductor
+        .call(
+            &bob_zome,
+            "get_deleted_{{snake_case (plural ../entry_type.name)}}_for_{{snake_case linked_from.name}}",
+            {{pascal_case ../entry_type.name}}::try_from({{snake_case ../entry_type.name}}.clone()).unwrap().{{field_name}}{{#if (eq cardinality "vector")}}[0]{{/if}},
+        )
+        .await;
+    assert_eq!(deleted_links_to_{{snake_case (plural linked_from.name)}}.len(), 1);
+      {{/if}}
+    {{/if}}
+  {{/each}}
+}
+{{/if}}

--- a/templates/generic/web-app/package.json.hbs
+++ b/templates/generic/web-app/package.json.hbs
@@ -1,14 +1,11 @@
 {
   "name": "{{app_name}}-dev",
   "private": true,
-  "workspaces": [
-    "ui",
-    "tests"
-  ],
+  "workspaces": ["ui"],
   "scripts": {
     "start": "AGENTS=${AGENTS:-2} BOOTSTRAP_PORT=$(get-port) {{(package_manager_command "network" null)}}",
     "network": "hc sandbox clean && {{(package_manager_command "build:happ" null)}} && UI_PORT=$(get-port) concurrently \"{{(package_manager_command "start" "ui")}}\" \"{{(package_manager_command "launch:happ" null)}}\" \"hc playground\"",
-    "test": "{{(package_manager_command "build:zomes" null)}} && hc app pack workdir --recursive && {{(package_manager_command "test" "tests")}}",
+    "test": "{{(package_manager_command "build:zomes" null)}} && hc app pack workdir --recursive && cargo test",
     "launch:happ": "hc-spin -n $AGENTS --ui-port $UI_PORT workdir/{{app_name}}.happ",
     "package": "{{(package_manager_command "build:happ" null)}} && {{(package_manager_command "package" "ui")}} && hc web-app pack workdir --recursive",
     "build:happ": "{{(package_manager_command "build:zomes" null)}} && hc app pack workdir --recursive",


### PR DESCRIPTION
This PR adds Rust tests when an entry type or a collection are scaffolded. It also adds unit tests for some of the used functions.

It was a nightmare to fiddle with Rust's idiosyncrasies like ownership that requires clones, strong typing etc. and all that having to always rebuild the whole binary to pick up the changed templates and then run through scaffolding a web-app and entries to see the changes in rendered files. Therefore the unit tests. Which are a bit easier to handle, but the repo structure is still pretty clunky.

Note that I haven't deleted anything Tryorama related yet, to make this PR easier to review.

resolves #533 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entry-type scaffolding now includes the integrity zome manifest so generated templates and tests reflect integrity-zome context.

* **Tests**
  * Vastly expanded unit/integration test scaffolding and helpers for entry types, collections, and zomes.
  * Test templates now use cargo test and include additional test utilities; added a dev-only assertion helper.

* **Chores**
  * Bumped multiple Holochain-related versions to dev releases.
  * Updated dev environment to Node.js 24, adjusted package/workspace scripts, and made test runner invocation more verbose while skipping npm test steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->