### PR TITLE
feat: add ELECTRON_BINARY env var override for flake.nix template

### DIFF
--- a/src/cli/custom-template/flake.nix
+++ b/src/cli/custom-template/flake.nix
@@ -16,6 +16,8 @@
       devShells.default = pkgs.mkShell {
         inputsFrom = [ inputs'.holonix.devShells.default ];
 
+        ELECTRON_BINARY = "${pkgs.electron_42}/bin/electron"; # Force `hc-spin` to use Electron from nixpkgs.
+
         packages = (with pkgs; [ nodejs_24 binaryen ]);
 
         shellHook = ''

--- a/src/cli/custom-template/flake.nix
+++ b/src/cli/custom-template/flake.nix
@@ -18,7 +18,11 @@
 
         ELECTRON_BINARY = "${pkgs.electron_42}/bin/electron"; # Force `hc-spin` to use Electron from nixpkgs.
 
-        packages = (with pkgs; [ nodejs_24 binaryen ]);
+        packages = (with pkgs; [
+          nodejs_24
+          binaryen
+          perl # Required to build OpenSSL from source
+        ]);
 
         shellHook = ''
           export PS1='\[\033[1;34m\][holonix:\w]\$\[\033[0m\] '

--- a/src/scaffold/app/nix.rs
+++ b/src/scaffold/app/nix.rs
@@ -35,6 +35,7 @@ pub fn flake_nix() -> FileTree {
         packages = (with pkgs; [
           nodejs_24
           binaryen
+          perl # Required to build OpenSSL from source
         ]);
 
         shellHook = ''

--- a/src/scaffold/app/nix.rs
+++ b/src/scaffold/app/nix.rs
@@ -30,8 +30,10 @@ pub fn flake_nix() -> FileTree {
       devShells.default = pkgs.mkShell {
         inputsFrom = [ inputs'.holonix.devShells.default ];
 
+        ELECTRON_BINARY = "${pkgs.electron_42}/bin/electron"; # Force `hc-spin` to use Electron from nixpkgs.
+
         packages = (with pkgs; [
-          nodejs_22
+          nodejs_24
           binaryen
         ]);
 


### PR DESCRIPTION
`ELECTRON_BINARY` is used by `hc-spin` to set the path to the Electron binary to use.

This forces `hc-spin` to use the Electron binary from nixpkgs, fixing known problems with running on NixOS and with installing Electron on certain Node.js versions.