### PR TITLE
Upgrade to Holochain 0.7.0-rc.4 (hdi 0.8.0-rc.3 / hdk 0.7.0-rc.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,59 @@ os.write(master, b"\x1b[B\r")  # Down, Enter — e.g. to answer "No"
   features enabled at the workspace level, that's likely a hand-edit on top
   of what was scaffolded, not something to replicate by default.
 
-## 6. If something looks like an upstream regression
+## 6. "It compiled yesterday" — crates.io drift during active RC cycles
+
+During an active RC cycle, `holochain`'s own transitive deps (`holochain_state`,
+`holochain_cascade`, `holochain_conductor_api`, ...) can get republished to
+crates.io *ahead of* a coordinated `holochain` release, breaking a fresh
+`cargo generate-lockfile` even though nothing in this repo or in `versions.rs`
+changed. Symptom: `cargo check --workspace --all-targets` fails **inside the
+`holochain` crate's own compilation** (not in the generated zome code) with
+errors like "no field `X`" or "this method takes N arguments" pointing at
+paths under `~/.cargo/registry/.../holochain-X.Y.Z-rc.N/...`.
+
+Diagnose by checking what actually resolved:
+
+```sh
+grep -A1 '^name = "holochain'  Cargo.lock   # in the affected app/test workspace
+```
+
+If a sibling crate (e.g. `holochain_state`) resolved to a *newer* pre-release
+than `holochain` itself, that's the drift. Confirm by trying to pin it back:
+
+```sh
+cargo update -p holochain_state --precise <holochain's-own-version>
+```
+
+If that fails ("candidate versions found which didn't match"), the sibling
+has already moved on and there's no going back — `holochain`'s own Cargo.toml
+now requires the newer sibling.
+
+**Do NOT try to decouple the `holochain` dev-dependency's version from
+`hdi`/`hdk`** (e.g. "pin the zome to hdi=rc.2 but let sweettest use a newer
+holochain") — this is not resolvable by Cargo. Enabling `test_utils`/
+`sweettest` on `holochain` activates its own optional `hdk` dependency, and
+Cargo unifies dependency resolution workspace-wide, so the exact `hdk` pin
+used by the zome crates conflicts with whatever `holochain` wants
+transitively. It fails outright with "failed to select a version for `hdk`".
+
+**The actual fix is to bump `hdi`/`hdk`/`holochain` together** to the next
+tag where upstream re-coordinated. Before assuming that requires new codegen
+work, diff `crates/hdi/src` and `crates/hdk/src` between the two tags — if
+empty, the bump is a pure version-string change in `versions.rs`, since the
+breakage was entirely inside `holochain`'s own conductor code, not in the
+zome-facing API:
+
+```sh
+gh api repos/holochain/holochain/compare/hdi-OLD...hdi-NEW \
+  -q '.files[] | .filename' | grep -E '^crates/(hdi|hdk)/src/'
+```
+
+Re-run the full §4 verification loop after any such bump — don't assume it's
+safe just because the source diff was empty; confirm `cargo check --workspace
+--all-targets` actually passes.
+
+## 7. If something looks like an upstream regression
 
 If the target release seems to have dropped a helper or introduced a logic
 gap with no replacement (not just a rename), don't paper over it with a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,168 @@
+# Upgrading Holochain versions
+
+This repo is a code generator: it writes Rust (hdi/hdk) source into scaffolded
+apps using `syn`/`quote` AST manipulation (not just Handlebars templates), so
+bumping the pinned Holochain version can require updating Rust code in this
+repo, not just a version string.
+
+## 1. Where the versions live
+
+`src/versions.rs` holds five constants:
+
+- `HOLOCHAIN_VERSION` (crates.io `holochain`)
+- `HDI_VERSION` (crates.io `hdi`)
+- `HDK_VERSION` (crates.io `hdk`)
+- `HOLOCHAIN_CLIENT_VERSION` (npm `@holochain/client`)
+- `HC_SPIN_VERSION` (npm `@holochain/hc-spin`)
+
+Find the matching set for a target Holochain release from the
+`holochain/holochain` GitHub repo tags (`holochain-X.Y.Z`, `hdi-X.Y.Z`,
+`hdk-X.Y.Z`) or crates.io/npmjs listings — the four crates are released
+together but with independent version numbers, so don't assume they move in
+lockstep.
+
+This repo does **not** pin `holochain_client` or `holochain_types` as Rust
+crates anywhere (only the npm client and the crates above). If a reference
+app has those in its workspace `Cargo.toml`, that's app-specific
+customization, not something this tool generates — don't add it here on
+their account.
+
+## 2. Where the HDI/HDK API surface is hard-coded
+
+The `validate()` callback and its match arms are built programmatically via
+`syn`/`quote`, so breaking changes to the `hdi::flat_op` module (`FlatOp`,
+`OpEntry`, `OpUpdate`, `OpDelete`, `OpLink`, `OpRecord`, `OpActivity`,
+`TypedAction`) or to the `Action`/`ActionData` shape need matching edits in:
+
+- `src/scaffold/zome/integrity.rs` — `initial_lib_rs()`: the base `validate()`
+  skeleton generated for a brand-new integrity zome (before any entry/link
+  types exist), plus the always-static `AgentActivity`/`CreateAgent` arm.
+- `src/scaffold/entry_type/integrity.rs` — `render_entry_definition_file()`
+  (the `validate_create_X`/`validate_update_X`/`validate_delete_X` function
+  signatures) and `add_entry_type_to_validation_arms()` + its `handle_*_arm`
+  helpers (the logic that finds the right match arm in an existing
+  `validate()` and inserts a new entry-type arm into it).
+- `src/scaffold/link_type/integrity.rs` — same idea for link types:
+  `validate_referenceable()`, the `validate_create_link_X`/
+  `validate_delete_link_X` signatures in `add_link_type_to_integrity_zome()`,
+  `add_link_type_to_validation_arms()`, and `add_link_type_signals()` /
+  `signal_action_match_arms()` (the coordinator-side `Signal::LinkCreated`/
+  `LinkDeleted` codegen).
+- `src/scaffold/entry_type/coordinator.rs` — `signal_action_match_arms()`
+  (the coordinator-side `Signal::EntryCreated`/`Updated`/`Deleted` codegen)
+  and the `match action.hashed.content...` skeleton it shares with the
+  file above.
+- `src/scaffold/zome/coordinator.rs` — `initial_cargo_toml()`: the
+  per-coordinator-zome dev-dependency feature list for the `holochain` crate
+  (used only for `#[tokio::test]` sweettest-based zome tests). Check this
+  against the real `holochain` crate's `[features]` table
+  (`crates/holochain/Cargo.toml` in `holochain/holochain` at the target tag)
+  — feature names get renamed/removed between releases (e.g.
+  `sqlite-encrypted` → `encryption`, `transport-iroh` removed in the
+  dev.23 → rc.3 jump).
+
+None of the above four files have unit tests that exercise the generated
+`validate()`/`signal_action` content end-to-end (the existing
+`src/templates/entry_type/tests/*` and `src/templates/link_type/tests/*`
+tests only cover the *coordinator test file* templates, not the integrity
+zome). **Always verify by actually running the CLI**, not by trusting
+`cargo test` — see §4.
+
+## 3. Finding the target API shape
+
+Don't guess the new API from memory. Two reliable sources, in order of
+preference:
+
+1. **A reference app's upgrade PR**, if the user provides one (e.g. an app
+   scaffolded by this tool that someone has since hand-upgraded). Diff its
+   `dnas/*/zomes/{integrity,coordinator}/*/src/*.rs` between the old and new
+   version — this shows the exact generated-code shape to target. Prefer
+   fetching the **final file state** at the PR's head branch (via `gh api
+   repos/<org>/<repo>/contents/<path>?ref=<branch>` + base64 decode) over
+   reconstructing it by hand from a diff — less error-prone for large
+   rewrites.
+2. **The `hdi` crate source itself**, at the exact target tag, e.g.:
+   `gh api repos/holochain/holochain/contents/crates/hdi/src/flat_op.rs?ref=hdi-X.Y.Z`
+   (and its `flat_op/` submodule: `flat_op_entry.rs`, `flat_op_record.rs`,
+   `flat_op_activity.rs`, `typed_action.rs`). This is the ground truth for
+   exact field names/types and is worth cross-checking even when you have a
+   reference app, since one app's usage may not exercise every code path
+   this tool needs to generate (e.g. the "no entry/link types yet" skeleton
+   state, which no scaffolded app ever ships with).
+
+## 4. Verifying the change
+
+Unit tests (`cargo test --lib` in this repo) only catch syntax errors in
+`quote!`/`syn::parse_quote!` blocks (checked at *this tool's* compile time)
+— they do **not** catch errors in the `syn::parse_str(...)` calls used to
+insert new match arms, since those only run when the CLI actually executes.
+End-to-end verification is required for any change to the four files in §2:
+
+```sh
+cargo build --bin hc-scaffold
+BIN=target/debug/hc-scaffold
+
+# web-app: --setup-nix has no non-interactive "no" — it always prompts
+# unless the flag is passed (which then tries to shell out to `nix`).
+# Either drive the prompt with a PTY (see below) or just skip web-app
+# and hand-write a minimal workspace Cargo.toml + `dna`/`zome` from there.
+"$BIN" -t headless web-app testapp "desc" --disable-fast-track
+
+cd testapp
+"$BIN" -t headless dna testapp
+"$BIN" -t headless zome testapp --dna testapp \
+  --integrity dnas/testapp/zomes/integrity \
+  --coordinator dnas/testapp/zomes/coordinator
+
+# Scaffold at least two entry types (one with a `linked_from` dependency,
+# to exercise deps_validation) and two link types (one deletable, one not),
+# to hit every insertion branch — first-arm-in-skeleton AND
+# subsequent-arm-push both need coverage.
+"$BIN" -t headless entry-type dino --dna testapp --zome testapp_integrity \
+  --crud crud --reference-entry-hash false \
+  --link-from-original-to-each-update false \
+  --fields "name:String:TextField" --no-ui
+"$BIN" -t headless entry-type nest --dna testapp --zome testapp_integrity \
+  --crud cr --reference-entry-hash false \
+  --fields "dino_hash:ActionHash::Dino" --no-ui
+"$BIN" -t headless link-type nest dino --dna testapp --zome testapp_integrity \
+  --bidirectional false --delete false --no-ui
+
+# The real test: does it compile against the *actual* target crates?
+cargo check -p testapp_integrity --lib   # fast, no dev-deps
+cargo check -p testapp --lib             # fast, no dev-deps
+cargo check --workspace --all-targets    # slow (~10+ min): pulls in the
+                                          # full `holochain` dev-dependency
+```
+
+If a `Select`/`Confirm` prompt can't be avoided via flags, drive it with a
+pty (plain piped stdin makes `dialoguer` redraw forever instead of erroring):
+
+```python
+# minimal pattern; see conversation history for a fuller version
+import pty, subprocess, os, time
+master, slave = pty.openpty()
+p = subprocess.Popen(cmd, stdin=slave, stdout=slave, stderr=slave)
+os.close(slave)
+time.sleep(3)
+os.write(master, b"\x1b[B\r")  # Down, Enter — e.g. to answer "No"
+```
+
+## 5. Things that are *not* pinned here (don't "fix" them)
+
+- **holonix** (`flake.nix`'s `holonix.url = "github:holochain/holonix?ref=main"`)
+  floats to `main` and is not version-pinned by this repo. It tracks
+  upstream Holochain releases on its own; no change needed here when
+  bumping versions.
+- **`sqlite-encrypted`/`encryption`, `transport-iroh`**: this tool has never
+  enabled `sqlite-encrypted`/`encryption` for the `holochain` dev-dependency
+  (only `wasmer-sys-cranelift` + `test_utils`). If a reference app has more
+  features enabled at the workspace level, that's likely a hand-edit on top
+  of what was scaffolded, not something to replicate by default.
+
+## 6. If something looks like an upstream regression
+
+If the target release seems to have dropped a helper or introduced a logic
+gap with no replacement (not just a rename), don't paper over it with a
+workaround — flag it and let the user decide. This is expected during RC
+cycles; upstream is often still actively fixing things.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,11 @@ apps using `syn`/`quote` AST manipulation (not just Handlebars templates), so
 bumping the pinned Holochain version can require updating Rust code in this
 repo, not just a version string.
 
+If the target release looks like it dropped a helper or introduced a logic
+gap with no replacement (not just a rename), don't paper over it with a
+workaround — flag it and let the user decide. This is expected during RC
+cycles; upstream is often still actively fixing things.
+
 ## 1. Where the versions live
 
 `src/versions.rs` holds five constants:
@@ -17,9 +22,9 @@ repo, not just a version string.
 
 Find the matching set for a target Holochain release from the
 `holochain/holochain` GitHub repo tags (`holochain-X.Y.Z`, `hdi-X.Y.Z`,
-`hdk-X.Y.Z`) or crates.io/npmjs listings — the four crates are released
-together but with independent version numbers, so don't assume they move in
-lockstep.
+`hdk-X.Y.Z`) for the three Rust crates, and the npmjs listings for the two
+npm packages — verify each independently, since the Rust crates and the npm
+packages come from different repos and don't necessarily move in lockstep.
 
 This repo does **not** pin `holochain_client` or `holochain_types` as Rust
 crates anywhere (only the npm client and the crates above). If a reference
@@ -57,11 +62,11 @@ The `validate()` callback and its match arms are built programmatically via
   (used only for `#[tokio::test]` sweettest-based zome tests). Check this
   against the real `holochain` crate's `[features]` table
   (`crates/holochain/Cargo.toml` in `holochain/holochain` at the target tag)
-  — feature names get renamed/removed between releases (e.g.
-  `sqlite-encrypted` → `encryption`, `transport-iroh` removed in the
-  dev.23 → rc.3 jump).
+  — feature names do get renamed or removed between releases, so a feature
+  list that compiled against the old target version isn't guaranteed to
+  still be valid.
 
-None of the above four files have unit tests that exercise the generated
+None of the above five files have unit tests that exercise the generated
 `validate()`/`signal_action` content end-to-end (the existing
 `src/templates/entry_type/tests/*` and `src/templates/link_type/tests/*`
 tests only cover the *coordinator test file* templates, not the integrity
@@ -92,11 +97,31 @@ preference:
 
 ## 4. Verifying the change
 
-Unit tests (`cargo test --lib` in this repo) only catch syntax errors in
-`quote!`/`syn::parse_quote!` blocks (checked at *this tool's* compile time)
-— they do **not** catch errors in the `syn::parse_str(...)` calls used to
-insert new match arms, since those only run when the CLI actually executes.
-End-to-end verification is required for any change to the four files in §2:
+**`run_test.sh` at the repo root is what CI actually runs (`testbuild` job)
+and is the authoritative acceptance test — it's much more thorough than any
+hand-rolled check.** It scaffolds a full "forum" app through the real CLI
+binary (svelte template, `hc-scaffold web-app/dna/zome/entry-type/
+collection/link-type`), covering scenarios a quick manual pass easily
+misses: `--reference-entry-hash true` entries, `Enum`/`Vec`/`Option` fields,
+agent-role and `:EntryHash`-suffixed link referenceables, bidirectional
+links, and multiple collection types. Then it runs `npm install && npm run
+test && npm run package` (JS side, plus a real wasm32 zome build) and
+`cargo clippy --all -- -D warnings`. If you're not sure a manual check is
+representative, this script is more likely to be right than your intuition
+about what to cover — it caught a real bug (`Record::new()`'s signature
+change, see below) that a narrower manual pass had missed.
+
+CI also independently runs `cargo fmt --all -- --check`, `cargo clippy
+--all-targets -- -D warnings`, and `cargo test --lib` as separate jobs — run
+all of these locally before considering a change to this repo done, not
+just `cargo build`/`cargo test`. A change that only touches `syn::parse_quote!`/
+`quote!` blocks (rather than the `syn::parse_str(...)` calls used to insert
+match arms) can still fail `cargo fmt --all -- --check` even though the
+tool's own build and tests pass — formatting is checked against the
+generator's own source, not the code it emits.
+
+For fast local iteration while developing a codegen change (not as a
+substitute for `run_test.sh` before considering the change verified):
 
 ```sh
 cargo build --bin hc-scaffold
@@ -115,24 +140,28 @@ cd testapp
   --coordinator dnas/testapp/zomes/coordinator
 
 # Scaffold at least two entry types (one with a `linked_from` dependency,
-# to exercise deps_validation) and two link types (one deletable, one not),
-# to hit every insertion branch — first-arm-in-skeleton AND
-# subsequent-arm-push both need coverage.
+# to exercise deps_validation, and one with `--reference-entry-hash true`)
+# and two link types (one deletable, one not), to hit every insertion
+# branch — first-arm-in-skeleton AND subsequent-arm-push both need coverage.
 "$BIN" -t headless entry-type dino --dna testapp --zome testapp_integrity \
   --crud crud --reference-entry-hash false \
   --link-from-original-to-each-update false \
   --fields "name:String:TextField" --no-ui
 "$BIN" -t headless entry-type nest --dna testapp --zome testapp_integrity \
-  --crud cr --reference-entry-hash false \
+  --crud cr --reference-entry-hash true \
   --fields "dino_hash:ActionHash::Dino" --no-ui
 "$BIN" -t headless link-type nest dino --dna testapp --zome testapp_integrity \
   --bidirectional false --delete false --no-ui
+"$BIN" -t headless link-type dino nest --dna testapp --zome testapp_integrity \
+  --bidirectional false --delete true --no-ui
 
-# The real test: does it compile against the *actual* target crates?
+# Does it compile against the *actual* target crates?
 cargo check -p testapp_integrity --lib   # fast, no dev-deps
 cargo check -p testapp --lib             # fast, no dev-deps
 cargo check --workspace --all-targets    # slow (~10+ min): pulls in the
                                           # full `holochain` dev-dependency
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
 ```
 
 If a `Select`/`Confirm` prompt can't be avoided via flags, drive it with a
@@ -154,67 +183,10 @@ os.write(master, b"\x1b[B\r")  # Down, Enter — e.g. to answer "No"
   floats to `main` and is not version-pinned by this repo. It tracks
   upstream Holochain releases on its own; no change needed here when
   bumping versions.
-- **`sqlite-encrypted`/`encryption`, `transport-iroh`**: this tool has never
-  enabled `sqlite-encrypted`/`encryption` for the `holochain` dev-dependency
-  (only `wasmer-sys-cranelift` + `test_utils`). If a reference app has more
-  features enabled at the workspace level, that's likely a hand-edit on top
-  of what was scaffolded, not something to replicate by default.
-
-## 6. "It compiled yesterday" — crates.io drift during active RC cycles
-
-During an active RC cycle, `holochain`'s own transitive deps (`holochain_state`,
-`holochain_cascade`, `holochain_conductor_api`, ...) can get republished to
-crates.io *ahead of* a coordinated `holochain` release, breaking a fresh
-`cargo generate-lockfile` even though nothing in this repo or in `versions.rs`
-changed. Symptom: `cargo check --workspace --all-targets` fails **inside the
-`holochain` crate's own compilation** (not in the generated zome code) with
-errors like "no field `X`" or "this method takes N arguments" pointing at
-paths under `~/.cargo/registry/.../holochain-X.Y.Z-rc.N/...`.
-
-Diagnose by checking what actually resolved:
-
-```sh
-grep -A1 '^name = "holochain'  Cargo.lock   # in the affected app/test workspace
-```
-
-If a sibling crate (e.g. `holochain_state`) resolved to a *newer* pre-release
-than `holochain` itself, that's the drift. Confirm by trying to pin it back:
-
-```sh
-cargo update -p holochain_state --precise <holochain's-own-version>
-```
-
-If that fails ("candidate versions found which didn't match"), the sibling
-has already moved on and there's no going back — `holochain`'s own Cargo.toml
-now requires the newer sibling.
-
-**Do NOT try to decouple the `holochain` dev-dependency's version from
-`hdi`/`hdk`** (e.g. "pin the zome to hdi=rc.2 but let sweettest use a newer
-holochain") — this is not resolvable by Cargo. Enabling `test_utils`/
-`sweettest` on `holochain` activates its own optional `hdk` dependency, and
-Cargo unifies dependency resolution workspace-wide, so the exact `hdk` pin
-used by the zome crates conflicts with whatever `holochain` wants
-transitively. It fails outright with "failed to select a version for `hdk`".
-
-**The actual fix is to bump `hdi`/`hdk`/`holochain` together** to the next
-tag where upstream re-coordinated. Before assuming that requires new codegen
-work, diff `crates/hdi/src` and `crates/hdk/src` between the two tags — if
-empty, the bump is a pure version-string change in `versions.rs`, since the
-breakage was entirely inside `holochain`'s own conductor code, not in the
-zome-facing API:
-
-```sh
-gh api repos/holochain/holochain/compare/hdi-OLD...hdi-NEW \
-  -q '.files[] | .filename' | grep -E '^crates/(hdi|hdk)/src/'
-```
-
-Re-run the full §4 verification loop after any such bump — don't assume it's
-safe just because the source diff was empty; confirm `cargo check --workspace
---all-targets` actually passes.
-
-## 7. If something looks like an upstream regression
-
-If the target release seems to have dropped a helper or introduced a logic
-gap with no replacement (not just a rename), don't paper over it with a
-workaround — flag it and let the user decide. This is expected during RC
-cycles; upstream is often still actively fixing things.
+- **Extra `holochain` crate features on a reference app**: this tool only
+  ever enables a small, fixed feature set on the `holochain` dev-dependency
+  (see `initial_cargo_toml()` in `src/scaffold/zome/coordinator.rs` for the
+  current list). If a reference app's `Cargo.toml` has more features
+  enabled at the workspace level than that, it's likely a hand-edit made
+  after scaffolding, not something this tool generated — don't replicate it
+  here just because a reference app has it.

--- a/src/scaffold/entry_type/coordinator.rs
+++ b/src/scaffold/entry_type/coordinator.rs
@@ -90,7 +90,7 @@ pub fn add_crud_functions_to_coordinator(
                             if find_ending_match_expr_in_block(&mut item_fn.block).is_none() {
                                 *item_fn.block = syn::parse_quote! {
                                     {
-                                        match action.hashed.content.clone() {
+                                        match &action.hashed.content.clone().data {
                                             _ => Ok(())
                                         }
                                     }
@@ -179,7 +179,7 @@ fn no_update_read_handler(entry_def: &EntryDefinition) -> TokenStream {
                         return Ok(None);
                     };
                     match details {
-                        Details::Entry(details) => Ok(Some(Record::new(details.actions[0].clone(), Some(details.entry)))),
+                        Details::Entry(details) => Ok(Some(Record::new(details.actions[0].clone(), RecordEntry::Present(details.entry)))),
                         _ => Err(wasm_error!(WasmErrorInner::Guest("Malformed get details response".to_string()))),
                     }
                 }
@@ -765,7 +765,7 @@ fn signal_entry_types_variants() -> ScaffoldResult<Vec<syn::Variant>> {
 fn signal_action_match_arms() -> ScaffoldResult<Vec<syn::Arm>> {
     Ok(vec![
         syn::parse_quote! {
-            Action::Create(_create) => {
+            ActionData::Create(_create) => {
                 if let Ok(Some(app_entry)) = get_entry_for_action(&action.hashed.hash) {
                     emit_signal(Signal::EntryCreated { action, app_entry })?;
                 }
@@ -773,7 +773,7 @@ fn signal_action_match_arms() -> ScaffoldResult<Vec<syn::Arm>> {
             }
         },
         syn::parse_quote! {
-            Action::Update(update) => {
+            ActionData::Update(update) => {
                 if let Ok(Some(app_entry)) = get_entry_for_action(&action.hashed.hash) {
                     if let Ok(Some(original_app_entry)) =
                         get_entry_for_action(&update.original_action_address)
@@ -789,7 +789,7 @@ fn signal_action_match_arms() -> ScaffoldResult<Vec<syn::Arm>> {
             }
         },
         syn::parse_quote! {
-            Action::Delete(delete) => {
+            ActionData::Delete(delete) => {
                 if let Ok(Some(original_app_entry)) = get_entry_for_action(&delete.deletes_address) {
                     emit_signal(Signal::EntryDeleted {
                         action,

--- a/src/scaffold/entry_type/integrity.rs
+++ b/src/scaffold/entry_type/integrity.rs
@@ -220,9 +220,9 @@ pub fn render_entry_definition_file(
 
     let validate_update = quote! {
         pub fn #validate_update_fn(
-            _action: Update,
+            _action: TypedAction<UpdateData>,
             #new_entry_arg: #name_pascal,
-            _original_action: EntryCreationAction,
+            _original_action: TypedAction<EntryCreationData>,
             #original_entry_arg: #name_pascal
         ) -> ExternResult<ValidateCallbackResult> {
             #validate_update_result
@@ -247,8 +247,8 @@ pub fn render_entry_definition_file(
 
     let validate_delete = quote! {
         pub fn #validate_delete_fn(
-            _action: Delete,
-            _original_action: EntryCreationAction,
+            _action: TypedAction<DeleteData>,
+            _original_action: TypedAction<EntryCreationData>,
             #deleted_post_arg: #name_pascal
         ) -> ExternResult<ValidateCallbackResult> {
             #validate_delete_result
@@ -334,7 +334,7 @@ pub fn render_entry_definition_file(
         #entry_def_token_stream
 
         pub fn #validate_create_fn(
-            _action: EntryCreationAction,
+            _action: TypedAction<EntryCreationData>,
             #create_new_entry_arg: #name_pascal
         ) -> ExternResult<ValidateCallbackResult> {
             #(#deps_validation)*
@@ -479,25 +479,25 @@ fn add_entry_type_to_validation_arms(
                         for arm in &mut match_expr.arms {
                             if let syn::Pat::TupleStruct(pat_tuple_struct) = &mut arm.pat {
                                 if let Some(path_segment) = pat_tuple_struct.path.segments.last() {
-                                    if path_segment.ident == "StoreRecord" {
+                                    if path_segment.ident == "CreateRecord" {
                                         handle_store_record_arm(
                                             arm,
                                             &pascal_entry_def_name,
                                             &snake_entry_def_name,
                                         )?;
-                                    } else if path_segment.ident == "StoreEntry" {
+                                    } else if path_segment.ident == "CreateEntry" {
                                         handle_store_entry_arm(
                                             arm,
                                             &pascal_entry_def_name,
                                             &snake_entry_def_name,
                                         )?;
-                                    } else if path_segment.ident == "RegisterUpdate" {
+                                    } else if path_segment.ident == "Update" {
                                         handle_register_update_arm(
                                             arm,
                                             &pascal_entry_def_name,
                                             &snake_entry_def_name,
                                         )?;
-                                    } else if path_segment.ident == "RegisterDelete" {
+                                    } else if path_segment.ident == "Delete" {
                                         handle_register_delete_arm(
                                             arm,
                                             &pascal_entry_def_name,
@@ -525,39 +525,14 @@ fn handle_store_record_arm(
             if is_entry(&op_record_arm.pat, "CreateEntry") {
                 // Add new entry type to match arm
                 if find_ending_match_expr(&mut op_record_arm.body).is_none() {
-                    // Change empty invalid to match on entry_type
-                    *op_record_arm.body = syn::parse_quote! {match app_entry {}};
-                }
-
-                // Add new entry type to match arm
-                if let Some(entry_type_match) = find_ending_match_expr(&mut op_record_arm.body) {
-                    let new_arm = syn::parse_str(&format!(
-                        r#"EntryTypes::{pascal_entry_def_name}({snake_entry_def_name}) => {{
-                            validate_create_{snake_entry_def_name}(
-                                EntryCreationAction::Create(action),
-                                {snake_entry_def_name},
-                            )
-                        }}"#
-                    ))?;
-                    entry_type_match.arms.push(new_arm);
-                }
-            } else if is_entry(&op_record_arm.pat, "UpdateEntry") {
-                // Add new entry type to match arm
-                if find_ending_match_expr(&mut op_record_arm.body).is_none() {
-                    // Change empty invalid to match on entry_type
+                    // Change empty invalid to match on entry_type, after narrowing the action
+                    // down to a `TypedAction<EntryCreationData>`. This two-step conversion may
+                    // be simplified once holochain/holochain#5910 lands.
                     *op_record_arm.body = syn::parse_quote! {
                         {
-                            let original_record = must_get_valid_record(original_action_hash)?;
-                            let original_action = original_record.action().clone();
-                            let original_action = match original_action {
-                                Action::Create(create) => EntryCreationAction::Create(create),
-                                Action::Update(update) => EntryCreationAction::Update(update),
-                                _ => {
-                                    return Ok(ValidateCallbackResult::Invalid(
-                                        "Original action for an update must be a Create or Update action".to_string()
-                                    ));
-                                }
-                            };
+                            let action: Action = action.into();
+                            let action: Result<TypedAction<EntryCreationData>, WrongActionError> = action.try_into();
+                            let action = action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
                             match app_entry {}
                         }
                     };
@@ -567,7 +542,39 @@ fn handle_store_record_arm(
                 if let Some(entry_type_match) = find_ending_match_expr(&mut op_record_arm.body) {
                     let new_arm = syn::parse_str(&format!(
                         r#"EntryTypes::{pascal_entry_def_name}({snake_entry_def_name}) => {{
-                            let result = validate_create_{snake_entry_def_name}(EntryCreationAction::Update(action.clone()), {snake_entry_def_name}.clone())?;
+                            validate_create_{snake_entry_def_name}(
+                                action,
+                                {snake_entry_def_name},
+                            )
+                        }}"#
+                    ))?;
+                    entry_type_match.arms.push(new_arm);
+                }
+            } else if is_entry(&op_record_arm.pat, "UpdateEntry") {
+                // Add new entry type to match arm
+                if find_ending_match_expr(&mut op_record_arm.body).is_none() {
+                    // Change empty invalid to match on entry_type, after narrowing both the
+                    // original and new actions down to `TypedAction<EntryCreationData>`. This
+                    // conversion may be simplified once holochain/holochain#5910 lands.
+                    *op_record_arm.body = syn::parse_quote! {
+                        {
+                            let original_record = must_get_valid_record(action.data.original_action_address.clone())?;
+                            let original_action = original_record.action().clone();
+                            let original_action: Result<TypedAction<EntryCreationData>, WrongActionError> = original_action.try_into();
+                            let original_action = original_action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+                            let creation_action: Action = action.clone().into();
+                            let creation_action: Result<TypedAction<EntryCreationData>, WrongActionError> = creation_action.try_into();
+                            let creation_action = creation_action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+                            match app_entry {}
+                        }
+                    };
+                }
+
+                // Add new entry type to match arm
+                if let Some(entry_type_match) = find_ending_match_expr(&mut op_record_arm.body) {
+                    let new_arm = syn::parse_str(&format!(
+                        r#"EntryTypes::{pascal_entry_def_name}({snake_entry_def_name}) => {{
+                            let result = validate_create_{snake_entry_def_name}(creation_action, {snake_entry_def_name}.clone())?;
                             if let ValidateCallbackResult::Valid = result {{
                                 let original_{snake_entry_def_name}: Option<{pascal_entry_def_name}> = original_record
                                     .entry()
@@ -597,20 +604,15 @@ fn handle_store_record_arm(
             } else if is_entry(&op_record_arm.pat, "DeleteEntry") {
                 // Add new entry type to match arm
                 if find_ending_match_expr(&mut op_record_arm.body).is_none() {
-                    // Change empty invalid to match on entry_type
+                    // Change empty invalid to match on entry_type, after narrowing the original
+                    // action down to a `TypedAction<EntryCreationData>`. This conversion may be
+                    // simplified once holochain/holochain#5910 lands.
                     *op_record_arm.body = syn::parse_quote! {
                         {
-                            let original_record = must_get_valid_record(original_action_hash)?;
+                            let original_record = must_get_valid_record(action.data.deletes_address.clone())?;
                             let original_action = original_record.action().clone();
-                            let original_action = match original_action {
-                                Action::Create(create) => EntryCreationAction::Create(create),
-                                Action::Update(update) => EntryCreationAction::Update(update),
-                                _ => {
-                                    return Ok(ValidateCallbackResult::Invalid(
-                                        "Original action for a delete must be a Create or Update action".to_string()
-                                    ));
-                                }
-                            };
+                            let original_action: Result<TypedAction<EntryCreationData>, WrongActionError> = original_action.try_into();
+                            let original_action = original_action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
                             let app_entry_type = match original_action.entry_type() {
                                 EntryType::App(app_entry_type) => app_entry_type,
                                 _ => {
@@ -669,11 +671,23 @@ fn handle_store_entry_arm(
 ) -> ScaffoldResult<()> {
     if let Some(op_entry_match_expr) = find_ending_match_expr(&mut arm.body) {
         for op_entry_arm in &mut op_entry_match_expr.arms {
-            if is_entry(&op_entry_arm.pat, "CreateEntry") {
-                // Add new entry type to match arm
+            if is_entry(&op_entry_arm.pat, "CreateEntry")
+                || is_entry(&op_entry_arm.pat, "UpdateEntry")
+            {
+                // Add new entry type to match arm, after narrowing the action down to a
+                // `TypedAction<EntryCreationData>` (both Create and Update actions are
+                // validated by the same `validate_create_*` function here)
                 if find_ending_match_expr(&mut op_entry_arm.body).is_none() {
-                    // Change empty invalid to match on entry_type
-                    *op_entry_arm.body = syn::parse_quote! {match app_entry {}};
+                    // Change empty invalid to match on entry_type. This conversion may be
+                    // simplified once holochain/holochain#5910 lands.
+                    *op_entry_arm.body = syn::parse_quote! {
+                        {
+                            let action: Action = action.into();
+                            let create_action: Result<TypedAction<EntryCreationData>, WrongActionError> = action.try_into();
+                            let create_action = create_action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+                            match app_entry {}
+                        }
+                    };
                 }
 
                 // Add new entry type to match arm
@@ -681,29 +695,10 @@ fn handle_store_entry_arm(
                     let new_arm = syn::parse_str(&format!(
                         r#"EntryTypes::{pascal_entry_def_name}({snake_entry_def_name}) => {{
                                 validate_create_{snake_entry_def_name}(
-                                    EntryCreationAction::Create(action),
+                                    create_action,
                                     {snake_entry_def_name},
                                 )
                         }},"#
-                    ))?;
-                    entry_type_match.arms.push(new_arm);
-                }
-            } else if is_entry(&op_entry_arm.pat, "UpdateEntry") {
-                // Add new entry type to match arm
-                if find_ending_match_expr(&mut op_entry_arm.body).is_none() {
-                    // Change empty invalid to match on entry_type
-                    *op_entry_arm.body = syn::parse_quote! {match app_entry {}};
-                }
-
-                // Add new entry type to match arm
-                if let Some(entry_type_match) = find_ending_match_expr(&mut op_entry_arm.body) {
-                    let new_arm = syn::parse_str(&format!(
-                        r#"EntryTypes::{pascal_entry_def_name}({snake_entry_def_name}) => {{
-                                validate_create_{snake_entry_def_name}(
-                                    EntryCreationAction::Update(action),
-                                    {snake_entry_def_name},
-                                )
-                        }}"#
                     ))?;
                     entry_type_match.arms.push(new_arm);
                 }
@@ -726,20 +721,16 @@ fn handle_register_update_arm(
                     if ps.ident == "Entry" {
                         // Add new entry type to match arm
                         if find_ending_match_expr(&mut op_entry_arm.body).is_none() {
-                            // Change empty invalid to match on entry_type
+                            // Change empty invalid to match on entry_type, after narrowing the
+                            // original action down to a `TypedAction<EntryCreationData>`. This
+                            // conversion may be simplified once holochain/holochain#5910 lands.
                             *op_entry_arm.body = syn::parse_quote! {
                                 {
-                                    let original_action = must_get_action(action.clone().original_action_address)?
+                                    let original_action = must_get_action(action.data.original_action_address.clone())?
                                         .action()
                                         .to_owned();
-                                    let original_create_action = match EntryCreationAction::try_from(original_action) {
-                                        Ok(action) => action,
-                                        Err(e) => {
-                                            return Ok(ValidateCallbackResult::Invalid(
-                                                format!("Expected to get EntryCreationAction from Action: {e:?}")
-                                            ));
-                                        }
-                                    };
+                                    let original_action: Result<TypedAction<EntryCreationData>, WrongActionError> = original_action.try_into();
+                                    let original_action = original_action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
                                     match app_entry {}
                                 }
                             };
@@ -751,7 +742,7 @@ fn handle_register_update_arm(
                         {
                             let new_arm = syn::parse_str(&format!(
                                 r#"EntryTypes::{pascal_entry_def_name}({snake_entry_def_name}) => {{
-                                    let original_app_entry = must_get_valid_record(action.clone().original_action_address)?;
+                                    let original_app_entry = must_get_valid_record(action.data.original_action_address.clone())?;
                                     let original_{snake_entry_def_name} = match {pascal_entry_def_name}::try_from(original_app_entry) {{
                                         Ok(entry) => entry,
                                         Err(e) => {{
@@ -763,7 +754,7 @@ fn handle_register_update_arm(
                                     validate_update_{snake_entry_def_name}(
                                         action,
                                         {snake_entry_def_name},
-                                        original_create_action,
+                                        original_action,
                                         original_{snake_entry_def_name},
                                     )
                                 }}"#,
@@ -784,17 +775,14 @@ fn handle_register_delete_arm(
     snake_entry_def_name: &str,
 ) -> ScaffoldResult<()> {
     if find_ending_match_expr(&mut arm.body).is_none() {
+        // Narrow the original action down to a `TypedAction<EntryCreationData>`. This
+        // conversion may be simplified once holochain/holochain#5910 lands.
         *arm.body = syn::parse_quote! {
             {
-                let original_action_hash = delete_entry.clone().action.deletes_address;
-                let original_record = must_get_valid_record(original_action_hash)?;
+                let original_record = must_get_valid_record(action.data.deletes_address.clone())?;
                 let original_record_action = original_record.action().clone();
-                let original_action = match EntryCreationAction::try_from(original_record_action) {
-                    Ok(action) => action,
-                    Err(e) => return Ok(ValidateCallbackResult::Invalid(format!(
-                        "Expected to get EntryCreationAction from Action: {e:?}"
-                    ))),
-                };
+                let original_action: Result<TypedAction<EntryCreationData>, WrongActionError> = original_record_action.try_into();
+                let original_action = original_action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
                 let app_entry_type = match original_action.entry_type() {
                     EntryType::App(app_entry_type) => app_entry_type,
                     _ => {
@@ -832,7 +820,7 @@ fn handle_register_delete_arm(
         let new_arm = syn::parse_str(&format!(
             r#"EntryTypes::{pascal_entry_def_name}(original_{snake_entry_def_name}) => {{
                 validate_delete_{snake_entry_def_name}(
-                    delete_entry.clone().action,
+                    action,
                     original_action,
                     original_{snake_entry_def_name}
                 )

--- a/src/scaffold/link_type/integrity.rs
+++ b/src/scaffold/link_type/integrity.rs
@@ -203,30 +203,24 @@ pub fn add_link_type_to_integrity_zome(
                     }
                 };
 
-                let base_address_ident = match from_referenceable {
-                    Some(Referenceable::EntryType(_)) => format_ident!("base_address"),
-                    _ => format_ident!("_base_address"),
-                };
-
                 let validate_create_from = from_referenceable
                     .as_ref()
-                    .map(|r| validate_referenceable(r, &base_address_ident));
-
-                let target_address_ident = match to_referenceable {
-                    Some(Referenceable::EntryType(_)) => format_ident!("target_address"),
-                    _ => format_ident!("_target_address"),
-                };
+                    .map(|r| validate_referenceable(r, &format_ident!("base_address")));
 
                 let validate_create_to = to_referenceable
                     .as_ref()
-                    .map(|r| validate_referenceable(r, &target_address_ident));
+                    .map(|r| validate_referenceable(r, &format_ident!("target_address")));
+
+                // `action` is only read from when there is a dependant entry type to check on
+                // either side of the link
+                let action_ident = match (&from_referenceable, &to_referenceable) {
+                    (None, None) => format_ident!("_action"),
+                    _ => format_ident!("action"),
+                };
 
                 let create_token_stream = quote! {
                     pub fn #validate_create_fn(
-                        _action: CreateLink,
-                        #base_address_ident: AnyLinkableHash,
-                        #target_address_ident: AnyLinkableHash,
-                        _tag: LinkTag,
+                        #action_ident: TypedAction<CreateLinkData>,
                     ) -> ExternResult<ValidateCallbackResult> {
                         #validate_create_from
 
@@ -239,11 +233,8 @@ pub fn add_link_type_to_integrity_zome(
 
                 let delete_token_stream = quote! {
                     pub fn #validate_delete_fn(
-                        _action: DeleteLink,
-                        _original_action: CreateLink,
-                        _base: AnyLinkableHash,
-                        _target: AnyLinkableHash,
-                        _tag: LinkTag
+                        _action: TypedAction<DeleteLinkData>,
+                        _original_action: TypedAction<CreateLinkData>,
                     ) -> ExternResult<ValidateCallbackResult> {
                         #validate_delete_result
                   }
@@ -287,7 +278,7 @@ pub fn add_link_type_to_integrity_zome(
 
 fn validate_referenceable(
     referenceable: &Referenceable,
-    address_ident: &syn::Ident,
+    address_field_ident: &syn::Ident,
 ) -> TokenStream {
     match referenceable {
         Referenceable::EntryType(entry_type) => {
@@ -298,7 +289,7 @@ fn validate_referenceable(
             if entry_type.reference_entry_hash {
                 quote! {
                     // Check the entry type for the given entry hash
-                    let entry_hash = #address_ident.into_entry_hash().ok_or(wasm_error!(WasmErrorInner::Guest("No entry hash associated with link".to_string())))?;
+                    let entry_hash = action.data.#address_field_ident.into_entry_hash().ok_or(wasm_error!(WasmErrorInner::Guest("No entry hash associated with link".to_string())))?;
                     let entry = must_get_entry(entry_hash)?.content;
 
                     let #entry_type_snake = crate::#entry_type_pascal::try_from(entry)?;
@@ -306,7 +297,7 @@ fn validate_referenceable(
             } else {
                 quote! {
                     // Check the entry type for the given action hash
-                    let action_hash = #address_ident.into_action_hash().ok_or(wasm_error!(
+                    let action_hash = action.data.#address_field_ident.into_action_hash().ok_or(wasm_error!(
                         WasmErrorInner::Guest("No action hash associated with link".to_string())
                     ))?;
                     let record = must_get_valid_record(action_hash)?;
@@ -351,7 +342,7 @@ fn add_link_type_signals(
                         if item_fn.sig.ident == "signal_action" {
                             if find_ending_match_expr_in_block(&mut item_fn.block).is_none() {
                                 *item_fn.block = syn::parse_str::<syn::Block>(
-                                    "{ match action.hashed.content.clone() { _ => Ok(()) } }",
+                                    "{ match &action.hashed.content.clone().data { _ => Ok(()) } }",
                                 )?;
                             }
 
@@ -413,7 +404,7 @@ fn signal_link_types_variants() -> ScaffoldResult<Vec<syn::Variant>> {
 fn signal_action_match_arms() -> ScaffoldResult<Vec<syn::Arm>> {
     Ok(vec![
         syn::parse_str::<syn::Arm>(
-            "Action::CreateLink(create_link) => {
+            "ActionData::CreateLink(create_link) => {
             if let Ok(Some(link_type)) =
                 LinkTypes::from_type(create_link.zome_index, create_link.link_type)
             {
@@ -423,14 +414,14 @@ fn signal_action_match_arms() -> ScaffoldResult<Vec<syn::Arm>> {
         }",
         )?,
         syn::parse_str::<syn::Arm>(
-            "Action::DeleteLink(delete_link) => {
+            "ActionData::DeleteLink(delete_link) => {
             let record = get(delete_link.link_add_address.clone(), GetOptions::default())?.ok_or(
                 wasm_error!(WasmErrorInner::Guest(
                     \"Failed to fetch CreateLink action\".to_string()
                 )),
             )?;
-            match record.action() {
-                Action::CreateLink(create_link) => {
+            match &record.action().data {
+                ActionData::CreateLink(create_link) => {
                     if let Ok(Some(link_type)) =
                         LinkTypes::from_type(create_link.zome_index, create_link.link_type)
                     {
@@ -485,130 +476,10 @@ fn add_link_type_to_validation_arms(
                         for arm in &mut match_expr.arms {
                             if let syn::Pat::TupleStruct(tuple_struct) = &mut arm.pat {
                                 if let Some(path_segment) = tuple_struct.path.segments.last() {
-                                    if path_segment.ident != "StoreRecord" {
-                                        continue;
-                                    }
-                                    if let Some(op_entry_match_expr) =
-                                        find_ending_match_expr(&mut arm.body)
-                                    {
-                                        for op_record_arm in &mut op_entry_match_expr.arms {
-                                            if is_create_link(&op_record_arm.pat) {
-                                                // Add new link type to match arm
-                                                if find_ending_match_expr(&mut op_record_arm.body)
-                                                    .is_none()
-                                                {
-                                                    // Change empty invalid to match on link_type
-                                                    *op_record_arm.body =
-                                                        syn::parse_str::<syn::Expr>(
-                                                            "match link_type {}",
-                                                        )?;
-                                                }
-
-                                                // Add new link type to match arm
-                                                if let Some(link_type_match) =
-                                                    find_ending_match_expr(&mut op_record_arm.body)
-                                                {
-                                                    let new_arm: syn::Arm = syn::parse_str(
-                                                                    format!(
-    "LinkTypes::{} => validate_create_link_{}(action, base_address, target_address, tag),",
-                                                                        link_type_name.to_case(Case::Pascal),
-                                                                        link_type_name.to_case(Case::Snake)
-                                                                    ).as_str()
-                                                                )?;
-                                                    link_type_match.arms.push(new_arm);
-                                                }
-                                            } else if is_delete_link(&op_record_arm.pat) {
-                                                // Add new link type to match arm
-                                                if find_ending_match_expr(&mut op_record_arm.body)
-                                                    .is_none()
-                                                {
-                                                    // Change empty invalid to match on link_type
-                                                    *op_record_arm.body = syn::parse_str::<
-                                                        syn::Expr,
-                                                    >(
-                                                        r#"{
-        let record = must_get_valid_record(original_action_hash)?;
-        let create_link = match record.action() {
-            Action::CreateLink(create_link) => create_link.clone(),
-            _ => {
-                return Ok(ValidateCallbackResult::Invalid("The action that a DeleteLink deletes must be a CreateLink".to_string()));
-            }
-        };
-        let link_type = match LinkTypes::from_type(create_link.zome_index, create_link.link_type)? {
-            Some(lt) => lt,
-            None => {
-                return Ok(ValidateCallbackResult::Valid);
-            }
-        };
-        match link_type {}
-    }"#,
-                                                    )?;
-                                                }
-
-                                                // Add new entry type to match arm
-                                                if let Some(link_type_match) =
-                                                    find_ending_match_expr(&mut op_record_arm.body)
-                                                {
-                                                    let new_arm: syn::Arm =
-                                                                    syn::parse_str(
-                                                                        format!(
-"LinkTypes::{} => validate_delete_link_{}(action, create_link.clone(), base_address, create_link.target_address, create_link.tag),",
-                                                                            link_type_name.to_case(Case::Pascal),
-                                                                            link_type_name.to_case(Case::Snake),
-                                                                        ).as_str()
-                                                                    )?;
-                                                    link_type_match.arms.push(new_arm);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            if let syn::Pat::Struct(pat_struct) = &mut arm.pat {
-                                if let Some(path_segment) = pat_struct.path.segments.last() {
-                                    if path_segment.ident == "RegisterCreateLink" {
-                                        // Add new link type to match arm
-                                        if find_ending_match_expr(&mut arm.body).is_none() {
-                                            // Change empty invalid to match on link_type
-                                            *arm.body =
-                                                syn::parse_str::<syn::Expr>("match link_type {}")?;
-                                        }
-
-                                        // Add new link type to match arm
-                                        if let Some(link_type_match) =
-                                            find_ending_match_expr(&mut arm.body)
-                                        {
-                                            let new_arm: syn::Arm = syn::parse_str(
-                                                format!(
-    "LinkTypes::{} => validate_create_link_{}(action, base_address, target_address, tag),",
-                                                            link_type_name.to_case(Case::Pascal),
-                                                            link_type_name.to_case(Case::Snake)
-                                                        )
-                                                .as_str(),
-                                            )?;
-                                            link_type_match.arms.push(new_arm);
-                                        }
-                                    } else if path_segment.ident == "RegisterDeleteLink" {
-                                        // Add new link type to match arm
-                                        if find_ending_match_expr(&mut arm.body).is_none() {
-                                            // Change empty invalid to match on link_type
-                                            *arm.body =
-                                                syn::parse_str::<syn::Expr>("match link_type {}")?;
-                                        }
-
-                                        // Add new link type to match arm
-                                        if let Some(link_type_match) =
-                                            find_ending_match_expr(&mut arm.body)
-                                        {
-                                            let new_arm: syn::Arm = syn::parse_str(
-                                                        format!(
-        "LinkTypes::{} => validate_delete_link_{}(action, original_action, base_address, target_address, tag),",
-                                                            link_type_name.to_case(Case::Pascal),
-                                                            link_type_name.to_case(Case::Snake)
-                                                        ).as_str()
-                                                    )?;
-                                            link_type_match.arms.push(new_arm);
-                                        }
+                                    if path_segment.ident == "CreateRecord" {
+                                        handle_create_record_link_arm(arm, link_type_name)?;
+                                    } else if path_segment.ident == "Link" {
+                                        handle_link_arm(arm, link_type_name)?;
                                     }
                                 }
                             }
@@ -618,5 +489,122 @@ fn add_link_type_to_validation_arms(
             }
         }
     }
+    Ok(())
+}
+
+fn handle_create_record_link_arm(arm: &mut syn::Arm, link_type_name: &str) -> ScaffoldResult<()> {
+    if let Some(op_entry_match_expr) = find_ending_match_expr(&mut arm.body) {
+        for op_record_arm in &mut op_entry_match_expr.arms {
+            if is_create_link(&op_record_arm.pat) {
+                // Add new link type to match arm
+                if find_ending_match_expr(&mut op_record_arm.body).is_none() {
+                    // Change empty invalid to match on link_type
+                    *op_record_arm.body = syn::parse_str::<syn::Expr>("match link_type {}")?;
+                }
+
+                // Add new link type to match arm
+                if let Some(link_type_match) = find_ending_match_expr(&mut op_record_arm.body) {
+                    let new_arm: syn::Arm = syn::parse_str(
+                        format!(
+                            "LinkTypes::{} => validate_create_link_{}(action),",
+                            link_type_name.to_case(Case::Pascal),
+                            link_type_name.to_case(Case::Snake)
+                        )
+                        .as_str(),
+                    )?;
+                    link_type_match.arms.push(new_arm);
+                }
+            } else if is_delete_link(&op_record_arm.pat) {
+                // Add new link type to match arm
+                if find_ending_match_expr(&mut op_record_arm.body).is_none() {
+                    // Change empty invalid to match on link_type, after re-deriving the
+                    // CreateLink action that this DeleteLink deletes
+                    *op_record_arm.body = syn::parse_str::<syn::Expr>(
+                        r#"{
+        let record = must_get_valid_record(action.data.link_add_address.clone())?;
+        let create_link = match &record.action().data {
+            ActionData::CreateLink(create_link) => TypedAction {
+                header: record.action().header.clone(),
+                data: create_link.clone(),
+            },
+            _ => {
+                return Ok(ValidateCallbackResult::Invalid("The action that a DeleteLink deletes must be a CreateLink".to_string()));
+            }
+        };
+        let link_type = match LinkTypes::from_type(create_link.data.zome_index, create_link.data.link_type)? {
+            Some(lt) => lt,
+            None => {
+                return Ok(ValidateCallbackResult::Valid);
+            }
+        };
+        match link_type {}
+    }"#,
+                    )?;
+                }
+
+                // Add new link type to match arm
+                if let Some(link_type_match) = find_ending_match_expr(&mut op_record_arm.body) {
+                    let new_arm: syn::Arm = syn::parse_str(
+                        format!(
+                            "LinkTypes::{} => validate_delete_link_{}(action, create_link),",
+                            link_type_name.to_case(Case::Pascal),
+                            link_type_name.to_case(Case::Snake),
+                        )
+                        .as_str(),
+                    )?;
+                    link_type_match.arms.push(new_arm);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn handle_link_arm(arm: &mut syn::Arm, link_type_name: &str) -> ScaffoldResult<()> {
+    let inner_pat = match &arm.pat {
+        syn::Pat::TupleStruct(tuple_struct) => tuple_struct.elems.first(),
+        _ => None,
+    };
+
+    if inner_pat.map(is_create_link).unwrap_or(false) {
+        // Add new link type to match arm
+        if find_ending_match_expr(&mut arm.body).is_none() {
+            // Change empty invalid to match on link_type
+            *arm.body = syn::parse_str::<syn::Expr>("match link_type {}")?;
+        }
+
+        // Add new link type to match arm
+        if let Some(link_type_match) = find_ending_match_expr(&mut arm.body) {
+            let new_arm: syn::Arm = syn::parse_str(
+                format!(
+                    "LinkTypes::{} => validate_create_link_{}(action),",
+                    link_type_name.to_case(Case::Pascal),
+                    link_type_name.to_case(Case::Snake)
+                )
+                .as_str(),
+            )?;
+            link_type_match.arms.push(new_arm);
+        }
+    } else if inner_pat.map(is_delete_link).unwrap_or(false) {
+        // Add new link type to match arm
+        if find_ending_match_expr(&mut arm.body).is_none() {
+            // Change empty invalid to match on link_type
+            *arm.body = syn::parse_str::<syn::Expr>("match link_type {}")?;
+        }
+
+        // Add new link type to match arm
+        if let Some(link_type_match) = find_ending_match_expr(&mut arm.body) {
+            let new_arm: syn::Arm = syn::parse_str(
+                format!(
+                    "LinkTypes::{} => validate_delete_link_{}(action, original_action),",
+                    link_type_name.to_case(Case::Pascal),
+                    link_type_name.to_case(Case::Snake)
+                )
+                .as_str(),
+            )?;
+            link_type_match.arms.push(new_arm);
+        }
+    }
+
     Ok(())
 }

--- a/src/scaffold/zome/coordinator.rs
+++ b/src/scaffold/zome/coordinator.rs
@@ -42,7 +42,7 @@ holochain_serialized_bytes = {{ workspace = true }}
 {deps}
 
 [dev-dependencies]
-holochain = {{ workspace = true, features = ["wasmer-sys-cranelift", "transport-iroh", "test_utils"] }}
+holochain = {{ workspace = true, features = ["wasmer-sys-cranelift", "test_utils"] }}
 tokio = {{ workspace = true }}
 "#,
     )
@@ -255,7 +255,6 @@ mod tests {
             *dep_holochain.get("features").unwrap().as_array().unwrap(),
             [
                 toml::Value::String("wasmer-sys-cranelift".to_string()),
-                toml::Value::String("transport-iroh".to_string()),
                 toml::Value::String("test_utils".to_string())
             ]
         );

--- a/src/scaffold/zome/integrity.rs
+++ b/src/scaffold/zome/integrity.rs
@@ -60,7 +60,7 @@ pub fn initial_lib_rs() -> TokenStream {
         #[hdk_extern]
         pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             match op.flattened::<(), ()>()? {
-                FlatOp::StoreEntry(store_entry) => match store_entry {
+                FlatOp::CreateEntry(create_entry) => match create_entry {
                     OpEntry::CreateEntry {
                         app_entry,
                         action,
@@ -76,7 +76,7 @@ pub fn initial_lib_rs() -> TokenStream {
                     )),
                     _ => Ok(ValidateCallbackResult::Valid)
                 },
-                FlatOp::RegisterUpdate(update_entry) => match update_entry {
+                FlatOp::Update(update_entry) => match update_entry {
                     OpUpdate::Entry { app_entry, action } => {
                         Ok(ValidateCallbackResult::Invalid(
                             "There are no entry types in this integrity zome".to_string(),
@@ -84,67 +84,54 @@ pub fn initial_lib_rs() -> TokenStream {
                     },
                     _ => Ok(ValidateCallbackResult::Valid)
                 },
-                FlatOp::RegisterDelete(delete_entry) => Ok(ValidateCallbackResult::Invalid(
+                FlatOp::Delete(OpDelete { action }) => Ok(ValidateCallbackResult::Invalid(
                     "There are no entry types in this integrity zome".to_string(),
                 )),
-                FlatOp::RegisterCreateLink {
+                FlatOp::Link(OpLink::CreateLink {
                     link_type,
-                    base_address,
-                    target_address,
-                    tag,
                     action
-                } => Ok(ValidateCallbackResult::Invalid(
+                }) => Ok(ValidateCallbackResult::Invalid(
                     "There are no link types in this integrity zome".to_string()
                 )),
-                FlatOp::RegisterDeleteLink {
+                FlatOp::Link(OpLink::DeleteLink {
                     link_type,
-                    base_address,
-                    target_address,
-                    tag,
                     original_action,
                     action
-                } => Ok(ValidateCallbackResult::Invalid("There are no link types in this integrity zome".to_string())),
-                FlatOp::StoreRecord(store_record) => match store_record {
-                    /// Complementary validation to the `StoreEntry` Op, in which the record itself is validated
-                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `StoreEntry`
-                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `StoreEntry` validation failed
+                }) => Ok(ValidateCallbackResult::Invalid("There are no link types in this integrity zome".to_string())),
+                FlatOp::CreateRecord(store_record) => match store_record {
+                    /// Complementary validation to the `CreateEntry` Op, in which the record itself is validated
+                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `CreateEntry`
+                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `CreateEntry` validation failed
                     OpRecord::CreateEntry {
                         app_entry,
                         action
                     } => Ok(ValidateCallbackResult::Invalid("There are no entry types in this integrity zome".to_string())),
-                    /// Complementary validation to the `RegisterUpdate` Op, in which the record itself is validated
-                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `StoreEntry` and in `RegisterUpdate`
+                    /// Complementary validation to the `Update` Op, in which the record itself is validated
+                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `CreateEntry` and in `Update`
                     /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the other validations failed
                     OpRecord::UpdateEntry {
-                        original_action_hash,
                         app_entry,
                         action,
                         ..
                     } => Ok(ValidateCallbackResult::Invalid("There are no entry types in this integrity zome".to_string())),
-                    /// Complementary validation to the `RegisterDelete` Op, in which the record itself is validated
-                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterDelete`
-                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterDelete` validation failed
+                    /// Complementary validation to the `Delete` Op, in which the record itself is validated
+                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `Delete`
+                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `Delete` validation failed
                     OpRecord::DeleteEntry {
-                        original_action_hash,
                         action,
                         ..
                     } => Ok(ValidateCallbackResult::Invalid("There are no entry types in this integrity zome".to_string())),
-                    /// Complementary validation to the `RegisterCreateLink` Op, in which the record itself is validated
-                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterCreateLink`
-                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterCreateLink` validation failed
+                    /// Complementary validation to the `Link(OpLink::CreateLink { .. })` Op, in which the record itself is validated
+                    /// If you want to optimize performance, you can remove the validation for a link type here and keep it in `Link`
+                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `Link` validation failed
                     OpRecord::CreateLink {
-                        base_address,
-                        target_address,
-                        tag,
                         link_type,
                         action
                     } => Ok(ValidateCallbackResult::Invalid("There are no link types in this integrity zome".to_string())),
-                    /// Complementary validation to the `RegisterDeleteLink` Op, in which the record itself is validated
-                    /// If you want to optimize performance, you can remove the validation for an entry type here and keep it in `RegisterDeleteLink`
-                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `RegisterDeleteLink` validation failed
+                    /// Complementary validation to the `Link(OpLink::DeleteLink { .. })` Op, in which the record itself is validated
+                    /// If you want to optimize performance, you can remove the validation for a link type here and keep it in `Link`
+                    /// Notice that doing so will cause `must_get_valid_record` for this record to return a valid record even if the `Link` validation failed
                     OpRecord::DeleteLink {
-                        original_action_hash,
-                        base_address,
                         action
                     } => Ok(ValidateCallbackResult::Invalid("There are no link types in this integrity zome".to_string())),
                     OpRecord::CreatePrivateEntry { .. } => Ok(ValidateCallbackResult::Valid),
@@ -159,14 +146,28 @@ pub fn initial_lib_rs() -> TokenStream {
                     OpRecord::InitZomesComplete { .. } => Ok(ValidateCallbackResult::Valid),
                     _ => Ok(ValidateCallbackResult::Valid)
                 },
-                FlatOp::RegisterAgentActivity(agent_activity) => match agent_activity {
-                    OpActivity::CreateAgent {
-                        agent,
-                        action
-                    } => {
-                        let previous_action = must_get_action(action.prev_action)?;
-                        match previous_action.action() {
-                            Action::AgentValidationPkg(AgentValidationPkg { membrane_proof, .. }) => validate_agent_joining(agent, membrane_proof),
+                FlatOp::AgentActivity(agent_activity) => match agent_activity {
+                    ref create @ OpActivity::CreateAgent { ref action } => {
+                        let prev = action
+                            .prev_action()
+                            .ok_or_else(|| {
+                                wasm_error!(WasmErrorInner::Guest("expected a prior action".into()))
+                            })?
+                            .clone();
+
+                        let agent = match create.agent() {
+                            Some(agent) => agent,
+                            None => {
+                                // Also expected to be checked by Holochain
+                                return Err(wasm_error!(WasmErrorInner::Guest(
+                                    "expected an agent key as the create data".into()
+                                )));
+                            }
+                        };
+
+                        let previous_action = must_get_action(prev)?;
+                        match &previous_action.action().data {
+                            ActionData::AgentValidationPkg(AgentValidationPkgData { membrane_proof, .. }) => validate_agent_joining(agent, membrane_proof),
                             _ => Ok(ValidateCallbackResult::Invalid("The previous action for a `CreateAgent` action must be an `AgentValidationPkg`".to_string()))
                         }
                     },

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,14 +1,14 @@
 /// npm: <https://www.npmjs.com/package/@holochain/client>
-pub const HOLOCHAIN_CLIENT_VERSION: &str = "^0.21.0-dev.2";
+pub const HOLOCHAIN_CLIENT_VERSION: &str = "^0.21.0-rc.1";
 
 /// npm: <https://www.npmjs.com/package/@holochain/hc-spin>
-pub const HC_SPIN_VERSION: &str = "^0.700.0-dev.1";
+pub const HC_SPIN_VERSION: &str = "^0.700.0-rc.1";
 
 /// crates.io <https://crates.io/crates/hdi/versions>
-pub const HDI_VERSION: &str = "0.8.0-dev.11";
+pub const HDI_VERSION: &str = "0.8.0-rc.2";
 
 /// crates.io <https://crates.io/crates/hdk/versions>
-pub const HDK_VERSION: &str = "0.7.0-dev.15";
+pub const HDK_VERSION: &str = "0.7.0-rc.2";
 
 /// crates.io <https://crates.io/crates/holochain/versions>
-pub const HOLOCHAIN_VERSION: &str = "0.7.0-dev.23";
+pub const HOLOCHAIN_VERSION: &str = "0.7.0-rc.3";

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -5,10 +5,10 @@ pub const HOLOCHAIN_CLIENT_VERSION: &str = "^0.21.0-rc.1";
 pub const HC_SPIN_VERSION: &str = "^0.700.0-rc.1";
 
 /// crates.io <https://crates.io/crates/hdi/versions>
-pub const HDI_VERSION: &str = "0.8.0-rc.2";
+pub const HDI_VERSION: &str = "0.8.0-rc.3";
 
 /// crates.io <https://crates.io/crates/hdk/versions>
-pub const HDK_VERSION: &str = "0.7.0-rc.2";
+pub const HDK_VERSION: &str = "0.7.0-rc.3";
 
 /// crates.io <https://crates.io/crates/holochain/versions>
-pub const HOLOCHAIN_VERSION: &str = "0.7.0-rc.3";
+pub const HOLOCHAIN_VERSION: &str = "0.7.0-rc.4";


### PR DESCRIPTION
## Summary
- Rewrites the `syn`/`quote`-based integrity zome `validate()` and coordinator `signal_action` codegen for the hdi API changes since 0.7.0-dev.23 (`FlatOp` variants renamed, `EntryCreationAction` replaced by `TypedAction<EntryCreationData>`, `Action` becoming a `{header, data}` struct, link validation functions collapsed to a single `TypedAction<CreateLinkData>` param), and drops a Cargo feature that no longer exists.
- Bumps `HOLOCHAIN_VERSION`/`HDI_VERSION`/`HDK_VERSION` to `0.7.0-rc.4`/`0.8.0-rc.3`/`0.7.0-rc.3` to route around a crates.io dependency drift where `holochain`'s own transitive deps had moved ahead of what `0.7.0-rc.3` itself was built against, breaking a fresh lockfile resolution for the sweettest dev-dependency.
- Adds `CLAUDE.md` documenting the upgrade process (where versions live, where the HDI/HDK API surface is hard-coded, how to find the target API shape, how to verify a change) for next time.