### PR TITLE
feat!: update scaffolded validate() codegen for Holochain 0.7.0-rc.5

### DIFF
--- a/src/scaffold/entry_type/integrity.rs
+++ b/src/scaffold/entry_type/integrity.rs
@@ -525,14 +525,11 @@ fn handle_store_record_arm(
             if is_entry(&op_record_arm.pat, "CreateEntry") {
                 // Add new entry type to match arm
                 if find_ending_match_expr(&mut op_record_arm.body).is_none() {
-                    // Change empty invalid to match on entry_type, after narrowing the action
-                    // down to a `TypedAction<EntryCreationData>`. This two-step conversion may
-                    // be simplified once holochain/holochain#5910 lands.
+                    // Change empty invalid to match on entry_type, after widening the Create
+                    // action to a `TypedAction<EntryCreationData>`
                     *op_record_arm.body = syn::parse_quote! {
                         {
-                            let action: Action = action.into();
-                            let action: Result<TypedAction<EntryCreationData>, WrongActionError> = action.try_into();
-                            let action = action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+                            let action: TypedAction<EntryCreationData> = action.into();
                             match app_entry {}
                         }
                     };
@@ -553,18 +550,14 @@ fn handle_store_record_arm(
             } else if is_entry(&op_record_arm.pat, "UpdateEntry") {
                 // Add new entry type to match arm
                 if find_ending_match_expr(&mut op_record_arm.body).is_none() {
-                    // Change empty invalid to match on entry_type, after narrowing both the
-                    // original and new actions down to `TypedAction<EntryCreationData>`. This
-                    // conversion may be simplified once holochain/holochain#5910 lands.
+                    // Change empty invalid to match on entry_type, after narrowing the original
+                    // action down to a `TypedAction<EntryCreationData>` and widening the new
+                    // Update action to the same type
                     *op_record_arm.body = syn::parse_quote! {
                         {
-                            let original_record = must_get_valid_record(action.data.original_action_address.clone())?;
-                            let original_action = original_record.action().clone();
-                            let original_action: Result<TypedAction<EntryCreationData>, WrongActionError> = original_action.try_into();
-                            let original_action = original_action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
-                            let creation_action: Action = action.clone().into();
-                            let creation_action: Result<TypedAction<EntryCreationData>, WrongActionError> = creation_action.try_into();
-                            let creation_action = creation_action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+                            let original_record = must_get_valid_record(action.original_action_address.clone())?;
+                            let original_action = TypedAction::<EntryCreationData>::try_from_action(original_record.action().clone())?;
+                            let creation_action: TypedAction<EntryCreationData> = action.clone().into();
                             match app_entry {}
                         }
                     };
@@ -605,14 +598,11 @@ fn handle_store_record_arm(
                 // Add new entry type to match arm
                 if find_ending_match_expr(&mut op_record_arm.body).is_none() {
                     // Change empty invalid to match on entry_type, after narrowing the original
-                    // action down to a `TypedAction<EntryCreationData>`. This conversion may be
-                    // simplified once holochain/holochain#5910 lands.
+                    // action down to a `TypedAction<EntryCreationData>`
                     *op_record_arm.body = syn::parse_quote! {
                         {
-                            let original_record = must_get_valid_record(action.data.deletes_address.clone())?;
-                            let original_action = original_record.action().clone();
-                            let original_action: Result<TypedAction<EntryCreationData>, WrongActionError> = original_action.try_into();
-                            let original_action = original_action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+                            let original_record = must_get_valid_record(action.deletes_address.clone())?;
+                            let original_action = TypedAction::<EntryCreationData>::try_from_action(original_record.action().clone())?;
                             let app_entry_type = match original_action.entry_type() {
                                 EntryType::App(app_entry_type) => app_entry_type,
                                 _ => {
@@ -674,17 +664,14 @@ fn handle_store_entry_arm(
             if is_entry(&op_entry_arm.pat, "CreateEntry")
                 || is_entry(&op_entry_arm.pat, "UpdateEntry")
             {
-                // Add new entry type to match arm, after narrowing the action down to a
+                // Add new entry type to match arm, after widening the action to a
                 // `TypedAction<EntryCreationData>` (both Create and Update actions are
                 // validated by the same `validate_create_*` function here)
                 if find_ending_match_expr(&mut op_entry_arm.body).is_none() {
-                    // Change empty invalid to match on entry_type. This conversion may be
-                    // simplified once holochain/holochain#5910 lands.
+                    // Change empty invalid to match on entry_type
                     *op_entry_arm.body = syn::parse_quote! {
                         {
-                            let action: Action = action.into();
-                            let create_action: Result<TypedAction<EntryCreationData>, WrongActionError> = action.try_into();
-                            let create_action = create_action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+                            let create_action: TypedAction<EntryCreationData> = action.into();
                             match app_entry {}
                         }
                     };
@@ -722,15 +709,13 @@ fn handle_register_update_arm(
                         // Add new entry type to match arm
                         if find_ending_match_expr(&mut op_entry_arm.body).is_none() {
                             // Change empty invalid to match on entry_type, after narrowing the
-                            // original action down to a `TypedAction<EntryCreationData>`. This
-                            // conversion may be simplified once holochain/holochain#5910 lands.
+                            // original action down to a `TypedAction<EntryCreationData>`. The
+                            // record is fetched here so each entry type arm can reuse it to
+                            // deserialize the original entry.
                             *op_entry_arm.body = syn::parse_quote! {
                                 {
-                                    let original_action = must_get_action(action.data.original_action_address.clone())?
-                                        .action()
-                                        .to_owned();
-                                    let original_action: Result<TypedAction<EntryCreationData>, WrongActionError> = original_action.try_into();
-                                    let original_action = original_action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+                                    let original_record = must_get_valid_record(action.original_action_address.clone())?;
+                                    let original_action = TypedAction::<EntryCreationData>::try_from_action(original_record.action().clone())?;
                                     match app_entry {}
                                 }
                             };
@@ -742,8 +727,7 @@ fn handle_register_update_arm(
                         {
                             let new_arm = syn::parse_str(&format!(
                                 r#"EntryTypes::{pascal_entry_def_name}({snake_entry_def_name}) => {{
-                                    let original_app_entry = must_get_valid_record(action.data.original_action_address.clone())?;
-                                    let original_{snake_entry_def_name} = match {pascal_entry_def_name}::try_from(original_app_entry) {{
+                                    let original_{snake_entry_def_name} = match {pascal_entry_def_name}::try_from(original_record) {{
                                         Ok(entry) => entry,
                                         Err(e) => {{
                                             return Ok(ValidateCallbackResult::Invalid(
@@ -775,14 +759,11 @@ fn handle_register_delete_arm(
     snake_entry_def_name: &str,
 ) -> ScaffoldResult<()> {
     if find_ending_match_expr(&mut arm.body).is_none() {
-        // Narrow the original action down to a `TypedAction<EntryCreationData>`. This
-        // conversion may be simplified once holochain/holochain#5910 lands.
+        // Narrow the original action down to a `TypedAction<EntryCreationData>`
         *arm.body = syn::parse_quote! {
             {
-                let original_record = must_get_valid_record(action.data.deletes_address.clone())?;
-                let original_record_action = original_record.action().clone();
-                let original_action: Result<TypedAction<EntryCreationData>, WrongActionError> = original_record_action.try_into();
-                let original_action = original_action.map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
+                let original_record = must_get_valid_record(action.deletes_address.clone())?;
+                let original_action = TypedAction::<EntryCreationData>::try_from_action(original_record.action().clone())?;
                 let app_entry_type = match original_action.entry_type() {
                     EntryType::App(app_entry_type) => app_entry_type,
                     _ => {

--- a/src/scaffold/link_type/integrity.rs
+++ b/src/scaffold/link_type/integrity.rs
@@ -276,6 +276,9 @@ pub fn add_link_type_to_integrity_zome(
     Ok(zome_file_tree)
 }
 
+/// Note: the emitted code addresses the link fields through `action.data`, not through
+/// `TypedAction`'s `Deref`. `into_entry_hash`/`into_action_hash` take `self` by value, and
+/// you cannot move out of a deref.
 fn validate_referenceable(
     referenceable: &Referenceable,
     address_field_ident: &syn::Ident,
@@ -517,21 +520,13 @@ fn handle_create_record_link_arm(arm: &mut syn::Arm, link_type_name: &str) -> Sc
             } else if is_delete_link(&op_record_arm.pat) {
                 // Add new link type to match arm
                 if find_ending_match_expr(&mut op_record_arm.body).is_none() {
-                    // Change empty invalid to match on link_type, after re-deriving the
-                    // CreateLink action that this DeleteLink deletes
+                    // Change empty invalid to match on link_type, after narrowing the action
+                    // that this DeleteLink deletes down to a `TypedAction<CreateLinkData>`
                     *op_record_arm.body = syn::parse_str::<syn::Expr>(
                         r#"{
-        let record = must_get_valid_record(action.data.link_add_address.clone())?;
-        let create_link = match &record.action().data {
-            ActionData::CreateLink(create_link) => TypedAction {
-                header: record.action().header.clone(),
-                data: create_link.clone(),
-            },
-            _ => {
-                return Ok(ValidateCallbackResult::Invalid("The action that a DeleteLink deletes must be a CreateLink".to_string()));
-            }
-        };
-        let link_type = match LinkTypes::from_type(create_link.data.zome_index, create_link.data.link_type)? {
+        let record = must_get_valid_record(action.link_add_address.clone())?;
+        let create_link = TypedAction::<CreateLinkData>::try_from_action(record.action().clone())?;
+        let link_type = match LinkTypes::from_type(create_link.zome_index, create_link.link_type)? {
             Some(lt) => lt,
             None => {
                 return Ok(ValidateCallbackResult::Valid);

--- a/src/scaffold/zome/integrity.rs
+++ b/src/scaffold/zome/integrity.rs
@@ -147,23 +147,13 @@ pub fn initial_lib_rs() -> TokenStream {
                     _ => Ok(ValidateCallbackResult::Valid)
                 },
                 FlatOp::AgentActivity(agent_activity) => match agent_activity {
-                    ref create @ OpActivity::CreateAgent { ref action } => {
+                    OpActivity::CreateAgent { agent, action } => {
                         let prev = action
                             .prev_action()
                             .ok_or_else(|| {
                                 wasm_error!(WasmErrorInner::Guest("expected a prior action".into()))
                             })?
                             .clone();
-
-                        let agent = match create.agent() {
-                            Some(agent) => agent,
-                            None => {
-                                // Also expected to be checked by Holochain
-                                return Err(wasm_error!(WasmErrorInner::Guest(
-                                    "expected an agent key as the create data".into()
-                                )));
-                            }
-                        };
 
                         let previous_action = must_get_action(prev)?;
                         match &previous_action.action().data {

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -5,10 +5,10 @@ pub const HOLOCHAIN_CLIENT_VERSION: &str = "^0.21.0-rc.1";
 pub const HC_SPIN_VERSION: &str = "^0.700.0-rc.1";
 
 /// crates.io <https://crates.io/crates/hdi/versions>
-pub const HDI_VERSION: &str = "0.8.0-rc.3";
+pub const HDI_VERSION: &str = "0.8.0-rc.4";
 
 /// crates.io <https://crates.io/crates/hdk/versions>
-pub const HDK_VERSION: &str = "0.7.0-rc.3";
+pub const HDK_VERSION: &str = "0.7.0-rc.4";
 
 /// crates.io <https://crates.io/crates/holochain/versions>
-pub const HOLOCHAIN_VERSION: &str = "0.7.0-rc.4";
+pub const HOLOCHAIN_VERSION: &str = "0.7.0-rc.5";


### PR DESCRIPTION
## Summary

Follows [holochain#5910](https://github.com/holochain/holochain/pull/5910) and the reference app upgrade in [dino-adventure#32](https://github.com/holochain/dino-adventure/pull/32).

- Bumps `holochain` to `0.7.0-rc.5` and `hdi`/`hdk` to `0.8.0-rc.4`/`0.7.0-rc.4`. The npm pins are unchanged — `@holochain/client` and `@holochain/hc-spin` are both still on `rc.1`. `wasmer-sys-cranelift` and `test_utils` still exist in `holochain` 0.7.0-rc.5, so the coordinator dev-dependency list needed no edit.
- Rewrites the `validate()` codegen for the new `TypedAction` conversions, clearing the three `TODO … once holochain/holochain#5910 lands` markers. Net **-34 lines** — this API exists to remove boilerplate the generator was emitting:
  - `TypedAction<CreateData>`/`<UpdateData>` now convert infallibly to `TypedAction<EntryCreationData>`, so the `Action` round trip + `try_into` + `map_err` collapses to `.into()`.
  - `TypedAction::<D>::try_from_action` returns `ExternResult`, replacing the `try_into` + `map_err` pairs and the hand-rolled `ActionData::CreateLink` match in the `DeleteLink` arm.
  - `OpActivity::CreateAgent` carries `agent` again, so the `Option`-returning accessor and its unreachable error arm are gone.
  - `TypedAction` derefs to its data, so `action.data.x` becomes `action.x` where the field is only read or cloned.

The version bump and the codegen change are atomic — the old codegen doesn't compile against hdi `0.8.0-rc.4` (the `agent()`/`new_key()`/`original_key()` accessors were removed) and the new codegen doesn't compile against `rc.3` (`try_from_action` didn't exist yet), so splitting them would leave a broken commit.

## Worth a look during review

- **`OpUpdate::Entry` now fetches the original record once** in the match scaffold and lets each entry-type arm reuse it, rather than every arm issuing its own `must_get_valid_record` for the same address. This follows the reference app and drops a redundant DHT fetch per update validation.
- **`validate_referenceable` deliberately keeps `action.data.base_address`** instead of using the new deref — `into_entry_hash`/`into_action_hash` take `self` by value and you can't move out of a deref. The reference app kept `.data` here too. Recorded as a source comment so it isn't "simplified" into a build failure later.
- **Behaviour change:** a `DeleteLink` whose target isn't a `CreateLink` now propagates an error rather than returning `ValidateCallbackResult::Invalid`. This follows the module doc holochain#5910 added — sys validation already guarantees that shape, so blaming the data's author for the violation is wrong.
- **Breaking for incremental scaffolding:** adding an entry type to an app scaffolded with an older release inserts arms referencing `original_record`, which won't exist in that app's older skeleton. Same class of break as #559.

## Verification

- `run_test.sh` (what CI's `testbuild` job runs) passes end to end: 22 sweettest zome tests green against a real conductor, plus the wasm32 build, `.webhapp` packaging, and `cargo clippy --all -- -D warnings` on the generated forum app.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (102 passed) all clean.
- Separately compiled the bare "no entry/link types yet" integrity zome skeleton — the one path `run_test.sh` never reaches, since it always adds entry types immediately. Its remaining warnings are all pre-existing unused-variable warnings on the placeholder arms.
- Cross-checked the API shape against `hdi-0.8.0-rc.4` itself, not just the reference app, per the process in `CLAUDE.md`.
